### PR TITLE
Normalise usage of test URI references.

### DIFF
--- a/Afurðir/IST-FUT-TN-FMTH-2020-08-17.yaml
+++ b/Afurðir/IST-FUT-TN-FMTH-2020-08-17.yaml
@@ -85,9 +85,9 @@ externalDocs:
   url: https://github.com/stadlar/IST-FUT-FMTH/tree/master/Berlin-group/v.1.3
 
 servers:
-  - url: https://api-psd2.openbanking.is
+  - url: https://api-psd2.testbank.is
     description: PSD2 server
-  - url: https://test-api-psd2.openbanking.is
+  - url: https://test-api-psd2.testbank.is
     description: Optional PSD2 test server
 
 

--- a/Afurðir/IST-FUT-TN-FMTH-2020-08-17.yaml
+++ b/Afurðir/IST-FUT-TN-FMTH-2020-08-17.yaml
@@ -85,9 +85,9 @@ externalDocs:
   url: https://github.com/stadlar/IST-FUT-FMTH/tree/master/Berlin-group/v.1.3
 
 servers:
-  - url: https://api-psd2.testbank.is
+  - url: https://api-psd2.example.com
     description: PSD2 server
-  - url: https://test-api-psd2.testbank.is
+  - url: https://test-api-psd2.example.com
     description: Optional PSD2 test server
 
 

--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -84,9 +84,9 @@ externalDocs:
   url: https://github.com/stadlar/IST-FUT-FMTH/tree/master/Vinnusv%C3%A6%C3%B0i/Stu%C3%B0ningsefni/Berlin-group/v.1.3.6
 
 servers:
-  - url: https://psd2.openbanking.is
+  - url: https://psd2.testbank.is
     description: PSD2 server
-  - url: https://sandbox-psd2.openbanking.is
+  - url: https://sandbox-psd2.testbank.is
     description: Optional PSD2 sandbox server
 
 paths:

--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -84,9 +84,9 @@ externalDocs:
   url: https://github.com/stadlar/IST-FUT-FMTH/tree/master/Vinnusv%C3%A6%C3%B0i/Stu%C3%B0ningsefni/Berlin-group/v.1.3.6
 
 servers:
-  - url: https://psd2.testbank.is
+  - url: https://psd2.example.com
     description: PSD2 server
-  - url: https://sandbox-psd2.testbank.is
+  - url: https://sandbox-psd2.example.com
     description: Optional PSD2 sandbox server
 
 paths:

--- a/Vinnusvæði/Verkþáttur 2/Examples/Flows/Single-payments-flow.md
+++ b/Vinnusvæði/Verkþáttur 2/Examples/Flows/Single-payments-flow.md
@@ -25,11 +25,11 @@ eIDAS certificate will be required, ask your ASPSP for a demo certificate for sa
 | Public certificate: openbankingPublicTPP.crt   |
 | Private certificate: openbankingPrivateTPP.key | 
 
-Sandbox URL: https://psd2.openbanking.is
+Sandbox URL: https://psd2.testbank.is
 
 ### Request example
 ```
-curl -X POST https://auth.openbanking.is/as/token.oauth2 \
+curl -X POST https://auth.testbank.is/as/token.oauth2 \
      -v \
      -cert openbankingPublicTPP.crt \
      -key openbankingPrivateTPP.key \
@@ -55,7 +55,7 @@ authorized by the account holder.
 ### Request example
 Icelandic Credit Transfer
 ```
-curl -X POST https://psd2.openbanking.is/v1/payments/icelandic-credit-transfer  \
+curl -X POST https://psd2.testbank.is/v1/payments/icelandic-credit-transfer  \
 -v \
 -H 'Accept: application/json'  \
 -H 'Authorization: Bearer UTUZnSKhYEYhX9qWl03epLVC3jyD' \
@@ -116,7 +116,7 @@ Location: /v1/payments/icelandic-credit-transfer/1234-wertiq-983
   "paymentId": "1234-wertiq-983",
   "_links": {
     "scaRedirect": {
-        "href": "https://psd2.openbanking.is/asdfasdfasdf"
+        "href": "https://psd2.testbank.is/asdfasdfasdf"
     },
     "self": {
         "href": "/v1/payments/sepa-credit-transfers/1234-wertiq-983"
@@ -139,7 +139,7 @@ Location: /v1/payments/icelandic-credit-transfer/1234-wertiq-983
   "_links": 
   {
     "scaOAuth": {
-        "href": "https://auth.openbanking.is/oauth/.well-known/oauth-authorization-server"
+        "href": "https://auth.testbank.is/oauth/.well-known/oauth-authorization-server"
     },
     "self": {   
         "href": "/v1/payments/1234-wertiq-983"
@@ -196,7 +196,7 @@ Location: /v1/payments/icelandic-credit-transfer/1234-wertiq-983
 ### Request example
 Icelandic Credit Transfer
 ```
-curl -X POST https://psd2.openbanking.is/v1/payments/icelandic-credit-transfer/1234-wertiq-983  \
+curl -X POST https://psd2.testbank.is/v1/payments/icelandic-credit-transfer/1234-wertiq-983  \
 -v \
 -H 'Accept: application/json'  \
 -H 'Authorization: Bearer UTUZnSKhYEYhX9qWl03epLVC3jyD' \

--- a/Vinnusvæði/Verkþáttur 2/Examples/Flows/Single-payments-flow.md
+++ b/Vinnusvæði/Verkþáttur 2/Examples/Flows/Single-payments-flow.md
@@ -25,11 +25,11 @@ eIDAS certificate will be required, ask your ASPSP for a demo certificate for sa
 | Public certificate: openbankingPublicTPP.crt   |
 | Private certificate: openbankingPrivateTPP.key | 
 
-Sandbox URL: https://psd2.testbank.is
+Sandbox URL: https://psd2.example.com
 
 ### Request example
 ```
-curl -X POST https://auth.testbank.is/as/token.oauth2 \
+curl -X POST https://auth.example.com/as/token.oauth2 \
      -v \
      -cert openbankingPublicTPP.crt \
      -key openbankingPrivateTPP.key \
@@ -55,7 +55,7 @@ authorized by the account holder.
 ### Request example
 Icelandic Credit Transfer
 ```
-curl -X POST https://psd2.testbank.is/v1/payments/icelandic-credit-transfer  \
+curl -X POST https://psd2.example.com/v1/payments/icelandic-credit-transfer  \
 -v \
 -H 'Accept: application/json'  \
 -H 'Authorization: Bearer UTUZnSKhYEYhX9qWl03epLVC3jyD' \
@@ -116,7 +116,7 @@ Location: /v1/payments/icelandic-credit-transfer/1234-wertiq-983
   "paymentId": "1234-wertiq-983",
   "_links": {
     "scaRedirect": {
-        "href": "https://psd2.testbank.is/asdfasdfasdf"
+        "href": "https://psd2.example.com/asdfasdfasdf"
     },
     "self": {
         "href": "/v1/payments/sepa-credit-transfers/1234-wertiq-983"
@@ -139,7 +139,7 @@ Location: /v1/payments/icelandic-credit-transfer/1234-wertiq-983
   "_links": 
   {
     "scaOAuth": {
-        "href": "https://auth.testbank.is/oauth/.well-known/oauth-authorization-server"
+        "href": "https://auth.example.com/oauth/.well-known/oauth-authorization-server"
     },
     "self": {   
         "href": "/v1/payments/1234-wertiq-983"
@@ -196,7 +196,7 @@ Location: /v1/payments/icelandic-credit-transfer/1234-wertiq-983
 ### Request example
 Icelandic Credit Transfer
 ```
-curl -X POST https://psd2.testbank.is/v1/payments/icelandic-credit-transfer/1234-wertiq-983  \
+curl -X POST https://psd2.example.com/v1/payments/icelandic-credit-transfer/1234-wertiq-983  \
 -v \
 -H 'Accept: application/json'  \
 -H 'Authorization: Bearer UTUZnSKhYEYhX9qWl03epLVC3jyD' \

--- a/Vinnusvæði/Verkþáttur 3/Examples/temp.yaml
+++ b/Vinnusvæði/Verkþáttur 3/Examples/temp.yaml
@@ -4,7 +4,7 @@ info:
   version: "1.0.0"
   title: Temp API
   contact:
-    email: gudmundurjon@openbanking.is
+    email: somebody@testbank.is
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/Vinnusvæði/Verkþáttur 3/Examples/temp.yaml
+++ b/Vinnusvæði/Verkþáttur 3/Examples/temp.yaml
@@ -4,7 +4,7 @@ info:
   version: "1.0.0"
   title: Temp API
   contact:
-    email: somebody@testbank.is
+    email: openbanking@stadlar.is
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'

--- a/Vinnusvæði/Verkþáttur 3/Meeting_minutes/README.md
+++ b/Vinnusvæði/Verkþáttur 3/Meeting_minutes/README.md
@@ -402,7 +402,7 @@ bunki2 =
     "amount": "123.50"
   },
   "_links": [
-    "https://www.testbank.is/fx/..."
+    "https://www.example.com/fx/..."
   ],
   "creditorAccount": {
     "iban": "DE02100100109307118603"

--- a/Vinnusvæði/Verkþáttur 3/Meeting_minutes/README.md
+++ b/Vinnusvæði/Verkþáttur 3/Meeting_minutes/README.md
@@ -402,7 +402,7 @@ bunki2 =
     "amount": "123.50"
   },
   "_links": [
-    "https://www.banki.is/fx/..."
+    "https://www.testbank.is/fx/..."
   ],
   "creditorAccount": {
     "iban": "DE02100100109307118603"

--- a/Vinnusvæði/Verkþáttur 4/IOBWS-Documents3.0.yaml
+++ b/Vinnusvæði/Verkþáttur 4/IOBWS-Documents3.0.yaml
@@ -665,7 +665,7 @@ components:
           format: byte
         fileRef:
           description: |
-            If the file is reference to an external reference, like https://www.testbank.is/files/file.pdf. If the field
+            If the file is reference to an external reference, like https://www.example.com/files/file.pdf. If the field
             'file' contains data then this field is disgarded.
           type: string
           format: uri

--- a/Vinnusvæði/Verkþáttur 4/IOBWS-Documents3.0.yaml
+++ b/Vinnusvæði/Verkþáttur 4/IOBWS-Documents3.0.yaml
@@ -665,7 +665,7 @@ components:
           format: byte
         fileRef:
           description: |
-            If the file is reference to an external reference, like https://www.openbanking.is/files/file.pdf. If the field
+            If the file is reference to an external reference, like https://www.testbank.is/files/file.pdf. If the field
             'file' contains data then this field is disgarded.
           type: string
           format: uri


### PR DESCRIPTION
## Context and Release description
Contains changes to URLs used in YAML, documentation and meeting notes, order to ensure they use example domains reserved for such use.

## Fix and Implications
Á nokkrum stöðum í skilgreiningum og aukaefni eru notuð dæmi um URI slóðir. T.d. er í upphaflegu YAML skilgreiningunum fyrir BerlinGroup NextGenPSD2 XS2A Framework vísað í [testbank.com](https://api.testbank.com/psd2) þar sem sýna þarf dæmi um slóð hjá AISPS eða PISP. Í hópavinnunni höfðu svo slæðst inn aðrar slóðir sem vísuðu hins vegar á skráð íslensk lén. Til að það sé augljósara að um dæmi er að ræða, og trufla síður m.a. útfærslu á biðlurum, er lögð til breyting sem vísar á example.com, sem er eitt þeirra léna sem er frátekið fyrir slík not sbr. [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606).  

## Test of correctness
No URIs in the Icelandic specific YAML extensions or associated descriptions, should resolve to actual registered domains. This leaves URIs indicating licenses, github paths and mailcontacts at Staðlaráð as well as those in the original BerlinGroup content. 