### PR TITLE
Feature/v6ts310and313 ab20220216

### DIFF
--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -6892,9 +6892,9 @@ components:
         batchBookingPreferred:
           type: boolean
 
-        debtorAccount: 
-            $ref: "#/components/schemas/accountReference"
-            
+        # debtorAccount: 
+        #     $ref: "#/components/schemas/accountReference"
+
         paymentInformationId:
           type: string
           maxLength: 35

--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -5080,14 +5080,7 @@ components:
         BICFI
       type: string
       pattern: '[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}'
-      example: "AAAADEBBXXX"
-    
-    
-    bicfiOrIdentification: 
-      description: |
-        BICFI or other organization identification
-      type: string
-      example: "AAAADEBBXXX or //FW123456789 or other"    
+      example: "AAAADEBBXXX"  
 
 
     pan:
@@ -6076,6 +6069,36 @@ components:
         Payment used to pay claim (Icelandic)
       type: boolean
       example: false
+
+    bicfiOrIdentification: 
+      description: |
+        BICFI or other organization identification
+      type: string
+      example: "AAAADEBBXXX or //FW123456789 or other"  
+
+    icelandicPurpose:
+      description: |
+        Standardised definition of icelandic purpose code and description used in transactions
+      type: object
+      properties:
+        code:
+          type: string
+          maxLength: 2
+        description:
+          type: string
+          maxLength: 150        
+
+    icelandicPurposeCode:
+      description: |
+        Standardised definition of transaction used in the Iceland market to define the purpose of the transaction.
+      type: string
+      maxLength: 2
+
+    centralBankPurposeCode:
+      description: |
+        Standardised definition of purpose code required by the Icelandic Central Bank.
+      type: string
+      maxLength: 3
     
     posEntryMode:
       description: |
@@ -6765,7 +6788,7 @@ components:
         creditorAddress:
           $ref: "#/components/schemas/address"
         creditorAgent:
-          $ref: "#/components/schemas/bicfi"
+          $ref: "#/components/schemas/bicfiOrIdentification"
         creditorAgentName:
           $ref: "#/components/schemas/creditorAgentName"
         creditorAgentAddress:
@@ -6854,6 +6877,8 @@ components:
         endToEndIdentification:
           type: string
           maxLength: 35
+        debtorAccount: 
+            $ref: "#/components/schemas/accountReference"
         paymentInformationId:
           type: string
           maxLength: 35
@@ -6862,9 +6887,6 @@ components:
         requestedExecutionDate:
           type: string
           format: date
-        requestedExecutionTime:
-          type: string
-          format: date-time
         payments:
           description: |
             A list of generic JSON bodies domestic payment initations for bulk payments via JSON.
@@ -7692,6 +7714,43 @@ components:
         Data MT942 format in a text structure.
       type: string
 
+    #####################################################
+    # Content of Response Bodies - Domestic
+    #####################################################
+
+    bulkPaymentInitiationDomesticWithStatusResponse: 
+      description: |
+        Generic JSON response body consistion of the corresponding bulk payment initation JSON body together with an optional transaction status field.
+      type: object
+      required:
+        - payments
+      properties:
+        batchBookingPreferred:
+          $ref: "#/components/schemas/batchBookingPreferred"
+        requestedExecutionDate:
+          type: string
+          format: date
+        debtorAccount:
+          $ref: "#/components/schemas/accountReference"
+        paymentInformationId:
+          type: string
+          maxLength: 35
+        payments:
+          description: |
+            A list of generic JSON bodies payment initations for bulk payments via JSON.
+            
+            Note: Some fields from single payments do not occcur in a bulk payment element
+          type: array
+          items:
+            $ref: "#/components/schemas/paymentInitiationBulkElementDomestic_json"
+        transactionStatus:
+          $ref: "#/components/schemas/transactionStatus"
+        chargesAccount:
+          $ref: "#/components/schemas/accountReference"
+        exchangeRateInformation: # N.A. for all, but can be used by ASPSP if needed
+          $ref: "#/components/schemas/paymentExchangeRate"
+        transactionFeesDetails:
+          $ref: "#/components/schemas/transactionFeesList"
 
 #####################################################
 # _links
@@ -11025,32 +11084,6 @@ components:
         }]
 
 
-    icelandicPurpose:
-      description: |
-        Standardised definition of icelandic purpose code and description used in transactions
-      type: object
-      properties:
-        code:
-          type: string
-          maxLength: 2
-        description:
-          type: string
-          maxLength: 150        
-
-
-    icelandicPurposeCode:
-      description: |
-        Standardised definition of transaction used in the Iceland market to define the purpose of the transaction.
-      type: string
-      maxLength: 2
-
-    centralBankPurposeCode:
-      description: |
-        Standardised definition of purpose code required by the Icelandic Central Bank.
-      type: string
-      maxLength: 3
-
-
   parameters:
   #####################################################
   # Predefined Parameters
@@ -11895,6 +11928,7 @@ components:
               - $ref: "#/components/schemas/paymentInitiationWithStatusResponse"
               - $ref: "#/components/schemas/periodicPaymentInitiationWithStatusResponse"
               - $ref: "#/components/schemas/bulkPaymentInitiationWithStatusResponse"
+              - $ref: "#/components/schemas/bulkPaymentInitiationDomesticWithStatusResponse"
               
         application/xml:
           schema:
@@ -12435,18 +12469,6 @@ components:
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
       #NO RESPONSE BODY
-
-    #####################################################
-    # Positive Responses Domestic
-    #####################################################
-
-    OK_200_PaymentId:
-      description: |
-        The payment id
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/paymentId"
 
     #####################################################
     # Negative Responses

--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -7874,7 +7874,8 @@ components:
         - $ref: "#/components/schemas/paymentInitiationBulkElementDomestic_json"
         - type: object
           properties:
-            status:
+            error:
+              nullable: true
               $ref: "#/components/schemas/tppMessage400_PIS"
           
 

--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -7731,6 +7731,106 @@ components:
     # Content of Response Bodies - Domestic
     #####################################################
 
+    paymentInitiationDomesticWithStatusResponse: 
+      description: |
+        Generic JSON response body consistion of the corresponding payment initation JSON body together with an optional transaction status field.
+      type: object
+      required:
+        - debtorAccount
+        - instructedAmount
+        - creditorAccount
+        - creditorName
+      properties:
+        endToEndIdentification:
+          type: string
+          maxLength: 35
+        debtorName: # N.A. for all, but can be used by ASPSP if needed
+          $ref: "#/components/schemas/debtorName"
+        debtorAccount: 
+          $ref: "#/components/schemas/accountReference"
+        debtorId: # N.A. for all, but can be used by ASPSP if needed
+          $ref: "#/components/schemas/debtorId"
+        ultimateDebtor: # N.A. for all, but can be used by ASPSP if needed
+          $ref: "#/components/schemas/ultimateDebtor"
+        instructedAmount:
+          $ref: "#/components/schemas/amount"
+        exchangeRateInformation: # N.A. for all, but can be used by ASPSP if needed
+          $ref: "#/components/schemas/paymentExchangeRate"
+        creditorAccount: 
+          $ref: "#/components/schemas/accountReference"
+        creditorAgent:
+          $ref: "#/components/schemas/bicfiOrIdentification"
+        creditorName:
+          $ref: "#/components/schemas/creditorName"
+        creditorAddress:
+          $ref: "#/components/schemas/address"
+        creditorId: # N.A. for all, but can be used by ASPSP if needed
+          description: Identification of Creditors, e.g. a SEPA Creditor ID.
+          type: string
+          maxLength: 35
+        ultimateCreditor: # N.A.
+          $ref: "#/components/schemas/ultimateCreditor"
+        chargeBearer: #In some payment product N.A. in some Optional in some conditional
+          $ref: "#/components/schemas/chargeBearer"
+        remittanceInformationUnstructured:
+          $ref: "#/components/schemas/remittanceInformationUnstructured"
+        remittanceInformationStructured: # N.A. for all, but can be used by ASPSP if needed
+          $ref: "#/components/schemas/remittanceInformationStructuredMax140"
+        requestedExecutionDate: # N.A. for all, but can be used by ASPSP if needed
+          type: string
+          format: date
+        transactionStatus:
+          $ref: "#/components/schemas/transactionStatus"
+        transactionFeesDetails:
+          $ref: "#/components/schemas/transactionFeesList"
+        icelandicPurposeCode:
+          $ref: "#/components/schemas/icelandicPurposeCode"
+        chargesAccount:
+          $ref: "#/components/schemas/accountReference"
+
+    periodicPaymentInitiationDomesticWithStatusResponse: 
+      description: |
+        Generic JSON response body consistion of the corresponding periodic payment initation JSON body together with an optional transaction status field.
+      type: object
+      required:
+        - debtorAccount
+        - instructedAmount
+        - creditorAccount
+        - creditorName
+        - startDate
+        - frequency
+      properties:
+        endToEndIdentification:
+          type: string
+          maxLength: 35
+        debtorAccount: 
+          $ref: "#/components/schemas/accountReference"
+        instructedAmount:
+          $ref: "#/components/schemas/amount"
+        creditorAccount: 
+          $ref: "#/components/schemas/accountReference"
+        creditorAgent:
+          $ref: "#/components/schemas/bicfiOrIdentification"
+        creditorName:
+          $ref: "#/components/schemas/creditorName"
+        creditorAddress:
+          $ref: "#/components/schemas/address"
+        remittanceInformationUnstructured:
+          $ref: "#/components/schemas/remittanceInformationUnstructured"
+        #Additional Information for periodic payments
+        startDate:
+          $ref: "#/components/schemas/startDate"
+        endDate:
+          $ref: "#/components/schemas/endDate"
+        executionRule:
+          $ref: "#/components/schemas/executionRule"
+        frequency:
+          $ref: "#/components/schemas/frequencyCode"
+        dayOfExecution:
+          $ref: "#/components/schemas/dayOfExecution"
+        transactionStatus:
+          $ref: "#/components/schemas/transactionStatus"
+
     bulkPaymentInitiationDomesticWithStatusResponse: 
       description: |
         Generic JSON response body consistion of the corresponding bulk payment initation JSON body together with an optional transaction status field.
@@ -7757,7 +7857,7 @@ components:
             Note: Some fields from single payments do not occcur in a bulk payment element
           type: array
           items:
-            $ref: "#/components/schemas/paymentInitiationBulkElementDomestic_json"
+            $ref: "#/components/schemas/bulkPaymentInitiationElementDomesticWithStatus"
         transactionStatus:
           $ref: "#/components/schemas/transactionStatus"
         chargesAccount:
@@ -7766,6 +7866,18 @@ components:
           $ref: "#/components/schemas/paymentExchangeRate"
         transactionFeesDetails:
           $ref: "#/components/schemas/transactionFeesList"
+
+    bulkPaymentInitiationElementDomesticWithStatus:
+      description: |
+        Bulk Element Response with status
+      allOf:
+        - $ref: "#/components/schemas/paymentInitiationBulkElementDomestic_json"
+        - type: object
+          properties:
+            status:
+              $ref: "#/components/schemas/tppMessage400_PIS"
+          
+
 
 #####################################################
 # _links
@@ -11943,6 +12055,8 @@ components:
               - $ref: "#/components/schemas/paymentInitiationWithStatusResponse"
               - $ref: "#/components/schemas/periodicPaymentInitiationWithStatusResponse"
               - $ref: "#/components/schemas/bulkPaymentInitiationWithStatusResponse"
+              - $ref: "#/components/schemas/paymentInitiationDomesticWithStatusResponse"
+              - $ref: "#/components/schemas/periodicPaymentInitiationDomesticWithStatusResponse"
               - $ref: "#/components/schemas/bulkPaymentInitiationDomesticWithStatusResponse"
               
         application/xml:

--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -8005,6 +8005,8 @@ components:
         * 'scaStatus': 
           The link to retrieve the scaStatus of the corresponding authorisation sub-resource. 
           This link is only contained, if an authorisation sub-resource has been already created.
+        * 'confirmAuthorisationWithTransactionAuthorisation':
+          The link
 
       type: object
       additionalProperties: 
@@ -8033,6 +8035,8 @@ components:
         status:
           $ref: "#/components/schemas/hrefType"
         scaStatus:
+          $ref: "#/components/schemas/hrefType"
+        confirmAuthorisationWithTransactionAuthorisation:
           $ref: "#/components/schemas/hrefType"
       example: 
         {

--- a/Deliverables/IOBWS3.0.yaml
+++ b/Deliverables/IOBWS3.0.yaml
@@ -6774,6 +6774,9 @@ components:
         endToEndIdentification:
           type: string
           maxLength: 35
+        instructionIdentification: # N.A. for all, but can be used by ASPSP if needed
+          type: string
+          maxLength: 35
         debtorId:
           type: string
           maxLength: 35
@@ -6891,6 +6894,7 @@ components:
 
         debtorAccount: 
             $ref: "#/components/schemas/accountReference"
+            
         paymentInformationId:
           type: string
           maxLength: 35


### PR DESCRIPTION
# Changes previously discussed and reviewed in VH-8.

Helst er þarna að efna að var upp tilllögu af response-um fyrir Get payment information. Í ljósi umræðunar um bulk WithStatusResponse var búinn til sérstök týpa og til samræmis, sömuleiðis samskonar týpur fyrir önnur _Domestic payment-product_. Í framhaldi voru breytingar sem áður höfðu verið gerðar á upprunalegu Berlin týpunum, teknar til baka svo samanburður við viðmiðunarskemað yrði sem þægilegastur.
Það bætist við einnig ný týpa fyrir greiðslurnar í bulk svarinu "bulkPaymentInitiationElementWithStatus"  sem að er okkar bulk element týpa auk "error" property sem er af týpunni "tppMessage400_PIS".
Þetta status eigindi er því með sömu gildum og við svörum í "Payment initiation request" þegar um villur er að ræða.

'Íslensku' týpurnar voru grúpper'aðar betur saman. Bætt var bicfiOrIdentification þannig að hún nýttist á 'domestic foreign týpununum.' Og hreinsuð út svæði og týpur sem máttu missa sín eftir fyrri breytingar.

Eftir að búið er að samþykkja þetta PR, ætti að vera hægt að vinna uppfærslur á villum, skjölun og dæmum á móti feature greininni.
