### PR TITLE
Claims - Use different schemas for batch initiation

### DIFF
--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -1502,12 +1502,12 @@ components:
           format: date-time
           example: "2022-12-31T08:05:15Z"
 
-    mergeDetailList:
+    mergeClaimDetailsList:
       description: |
-        List of claim to be altered
+        List of claims to be altered
       type: array
       items:
-        $ref: "#/components/schemas/mergeClaimDetails"
+        $ref: "#/components/schemas/mergeClaimBatchDetails"
 
     mergeClaimDetails:
       description: |
@@ -1580,6 +1580,12 @@ components:
           $ref: "#/components/schemas/collectionState"
         printing:
           $ref: "#/components/schemas/printing"
+    
+    mergeClaimBatchDetails:
+      allOf: 
+        -  $ref: "#/components/schemas/mergeClaimDetails"
+      required: 
+        -  claimKey
 
 
     createClaimDetailList:
@@ -1676,18 +1682,21 @@ components:
         printing:
           $ref: "#/components/schemas/printing"
 
-    batchInitiation:
+    batchCreateInitiation:
       properties:
         createList:
           $ref: "#/components/schemas/createClaimDetailList"
+    
+    batchMergeInitiation:
+      properties:
         mergeList:
-          $ref: "#/components/schemas/mergeDetailList"
+          $ref: "#/components/schemas/mergeClaimDetailsList"
 
     # RESPONSES
 
-    patchStatus:
+    batchStatus:
       description: | 
-        Status of an batch initiation
+        Status of a batch initiation
       properties:
         batchId:
           $ref: "#/components/schemas/batchId"
@@ -1704,7 +1713,7 @@ components:
           type: string
           enum:
             - "create"
-            - "alter"
+            - "merge"
         actions:
           $ref: "#/components/schemas/claimStatusResponse"
 
@@ -2500,12 +2509,14 @@ components:
 
     batchInitiation:
       description: |
-        JSON request body for a list of actions inition request message
+        JSON request body for a list of create actions inition request message
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/batchInitiation"
+            oneOf: 
+              - $ref: "#/components/schemas/batchCreateInitiation"
+              - $ref: "#/components/schemas/batchMergeInitiation"
 
     templateCode:
       description: |
@@ -2572,14 +2583,14 @@ components:
     #####################################################
 
     OK_20x_ActionResponse:
-      description: Patch created
+      description: Batch created
       headers:
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/patchStatus"
+            $ref: "#/components/schemas/batchStatus"
           examples:
             "Example":
               $ref: "#/components/examples/patchBatch-200_Example"

--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -604,7 +604,7 @@ paths:
 
         **batchCreateInitiation** - Initiates a batch with a list of claims to be created.
 
-        **batchMergeInitiation** - Initiates a batch with a list of claims to be altered.
+        **batchAlterInitiation** - Initiates a batch with a list of claims to be altered.
         
         When claim is altered:
           The patch claim method modifies a previously created claim. The patch is
@@ -1505,12 +1505,12 @@ components:
           format: date-time
           example: "2022-12-31T08:05:15Z"
 
-    mergeClaimDetailsList:
+    alterClaimDetailsList:
       description: |
         List of claims to be altered
       type: array
       items:
-        $ref: "#/components/schemas/mergeClaimBatchDetails"
+        $ref: "#/components/schemas/alterClaimBatchDetails"
 
     mergeClaimDetails:
       description: |
@@ -1584,7 +1584,7 @@ components:
         printing:
           $ref: "#/components/schemas/printing"
     
-    mergeClaimBatchDetails:
+    alterClaimBatchDetails:
       allOf: 
         -  $ref: "#/components/schemas/mergeClaimDetails"
       required: 
@@ -1690,10 +1690,10 @@ components:
         createList:
           $ref: "#/components/schemas/createClaimDetailList"
     
-    batchMergeInitiation:
+    batchAlterInitiation:
       properties:
-        mergeList:
-          $ref: "#/components/schemas/mergeClaimDetailsList"
+        alterList:
+          $ref: "#/components/schemas/alterClaimDetailsList"
 
     # RESPONSES
 
@@ -1716,7 +1716,7 @@ components:
           type: string
           enum:
             - "create"
-            - "merge"
+            - "alter"
         actions:
           $ref: "#/components/schemas/claimStatusResponse"
 
@@ -2519,7 +2519,7 @@ components:
           schema:
             oneOf: 
               - $ref: "#/components/schemas/batchCreateInitiation"
-              - $ref: "#/components/schemas/batchMergeInitiation"
+              - $ref: "#/components/schemas/batchAlterInitiation"
 
     templateCode:
       description: |

--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -1687,13 +1687,23 @@ components:
 
     batchCreateInitiation:
       properties:
+        actionType:
+          $ref: "#/components/schemas/actionType"
         createList:
           $ref: "#/components/schemas/createClaimDetailList"
     
     batchAlterInitiation:
       properties:
+        actionType:
+          $ref: "#/components/schemas/actionType"
         alterList:
           $ref: "#/components/schemas/alterClaimDetailsList"
+    
+    actionType:
+      type: string
+      enum:
+        - "create"
+        - "alter"
 
     # RESPONSES
 
@@ -1713,10 +1723,7 @@ components:
           type: integer
           description: Number of items pending processing
         actionType:
-          type: string
-          enum:
-            - "create"
-            - "alter"
+          $ref: "#/components/schemas/actionType"
         actions:
           $ref: "#/components/schemas/claimStatusResponse"
 
@@ -2517,6 +2524,11 @@ components:
       content:
         application/json:
           schema:
+            discriminator:
+              propertyName: actionType
+              mapping:
+                create: "#/components/schemas/batchCreateInitiation"
+                alter: "#/components/schemas/batchAlterInitiation"
             oneOf: 
               - $ref: "#/components/schemas/batchCreateInitiation"
               - $ref: "#/components/schemas/batchAlterInitiation"

--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -600,8 +600,11 @@ paths:
     post:
       summary: Creates a batch. Batch is a list of actions defined in the body
       description: |
-        Creates a list of claims defined by the request body object to be created and/or 
-        alters a list of claims defined by the same object.
+        Accepts on of two request bodies that indicate the action type:
+
+        **batchCreateInitiation** - Initiates a batch with a list of claims to be created.
+
+        **batchMergeInitiation** - Initiates a batch with a list of claims to be altered.
         
         When claim is altered:
           The patch claim method modifies a previously created claim. The patch is
@@ -2509,7 +2512,7 @@ components:
 
     batchInitiation:
       description: |
-        JSON request body for a list of create actions inition request message
+        JSON request body for a list of create or alter actions inition request message
       required: true
       content:
         application/json:


### PR DESCRIPTION
Use different schemas for batch initiation payload to indicate intended action type.
#171 