### PR TITLE
Claims - Renamed isPermitOutOfSequencePayment to isOutOfSequencePaymentAllowed

### DIFF
--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -1470,7 +1470,7 @@ components:
           $ref: "#/components/schemas/defaultInterest"
         discount:
           $ref: "#/components/schemas/discount"
-        isPermitOutOfSequencePayment:
+        isOutOfSequencePaymentAllowed:
           description: Payment rule, is it allowed to pay the last payment if previous has not been paid
           type: boolean
         isPartialPaymentAllowed:
@@ -1556,7 +1556,7 @@ components:
           $ref: "#/components/schemas/defaultInterest"
         discount:
           $ref: "#/components/schemas/discount"
-        isPermitOutOfSequencePayment:
+        isOutOfSequencePaymentAllowed:
           description: Payment rule, is it allowed to pay the last payment if previous has not been paid
           type: boolean
         isPartialPaymentAllowed:
@@ -1600,8 +1600,7 @@ components:
                          the amount must be within the rules that apply according to Regulation 37/2009.
         * defaultInterest: Contains information on how penalty interest is calculated.
         * discount: Contains information about discount as constant or percent
-        * isPermitOutOfSequencePayment: Out of sequence payment allowed
-        * isPartialPaymentAllowed: Partial payment is allowed
+        * isOutOfSequencePaymentAllowed: Out of sequence payment allowed
         * isPartialPaymentAllowed: Partial payment is allowed
       type: object
       required:
@@ -1656,7 +1655,7 @@ components:
           $ref: "#/components/schemas/defaultInterest"
         discount:
           $ref: "#/components/schemas/discount"
-        isPermitOutOfSequencePayment:
+        isOutOfSequencePaymentAllowed:
           description: Payment rule, is it allowed to pay the last payment if previous has not been paid
           type: boolean
         isPartialPaymentAllowed:
@@ -3014,7 +3013,7 @@ components:
               "amount": 0
             }
           },
-          "isPermitOutOfSequencePayment": true,
+          "isOutOfSequencePaymentAllowed": true,
           "isPartialPaymentAllowed": true,
           "isPartiallyPaid": true,
           "currency": "string",
@@ -3168,7 +3167,7 @@ components:
                   "amount": 0
                 }
               },
-              "isPermitOutOfSequencePayment": true,
+              "isOutOfSequencePaymentAllowed": true,
               "isPartialPaymentAllowed": true,
               "isPartiallyPaid": true,
               "currency": "string",
@@ -3319,7 +3318,7 @@ components:
                 "amount": 0
               }
             },
-            "isPermitOutOfSequencePayment": true,
+            "isOutOfSequencePaymentAllowed": true,
             "isPartialPaymentAllowed": true,
             "isPartiallyPaid": true,
             "currency": "string",
@@ -3409,7 +3408,7 @@ components:
               "amount": 0
             }
           },
-          "isPermitOutOfSequencePayment": true,
+          "isOutOfSequencePaymentAllowed": true,
           "isPartialPaymentAllowed": true,
           "currency": "string",
           "referenceRate": "ExchangeRate",


### PR DESCRIPTION
Renamed isPermitOutOfSequencePayment to isOutOfSequencePaymentAllowed for a mopre natural phrasing and better corresponding with isPartialPaymentAllowed.
#168 