### PR TITLE
Renamed properties in claimTransaction

### DIFF
--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -1836,8 +1836,8 @@ components:
         depositedAmount:
           description: The amount deposited at the creditor's account.
           type: integer
-        totalAmount:
-          description: Total amount paid with accrued interest and fees.
+        totalAmountPaid:
+          description: Total amount paid with accrued interests and fees.
           type: integer
         capitalGainsTax:
           description: Deducted capital gains tax.
@@ -1853,21 +1853,23 @@ components:
             claim with the creditor. Necessary if a direct payment agreement is to be established
           type: string
           maxLength: 16
-        noticeChargeAmount:
+        noticeChargeAmountPaid:
+          description: Notice charge paid.
           type: integer
-        defaultChargeAmount:
+        defaultChargeAmountPaid:
+          description: Default charge paid.
           type: integer
-        otherCostsAmount:
-          description: Otherwise cost to pay.
+        otherCostsAmountPaid:
+          description: Other costs paid.
           type: integer
-        otherDefaultCostsAmount:
-          description: Other default paid.
+        otherDefaultCostsAmountPaid:
+          description: Other default costs paid.
           type: integer
-        defaultInterestAmount:
-          description: Amount of accrued penalty interest paid.
+        defaultInterestAmountPaid:
+          description: Amount of accrued penalty interests paid.
           type: integer
-        discountAmount:
-          description: Discount that was granted when a claim was paid.
+        discountAmountGiven:
+          description: Discount that was granted when the claim was paid.
           type: integer
         currency:
           type: string
@@ -3074,16 +3076,16 @@ components:
             "valueDate": "2022-01-31",
             "paymentType": "Complete",
             "depositedAmount": 0,
-            "totalAmount": 0,
+            "totalAmountPaid": 0,
             "capitalGainsTax": 0,
             "billNumber": "string",
             "customerNumber": "string",
-            "noticeChargeAmount": 0,
-            "defaultChargeAmount": 0,
-            "otherCostsAmount": 0,
-            "otherDefaultCostsAmount": 0,
-            "defaultInterestAmount": 0,
-            "discountAmount": 0,
+            "noticeChargeAmountPaid": 0,
+            "defaultChargeAmountPaid": 0,
+            "otherCostsAmountPaid": 0,
+            "otherDefaultCostsAmountPaid": 0,
+            "defaultInterestAmountPaid": 0,
+            "discountAmountGiven": 0,
             "currency": "string",
             "currencyExchange": {
               "currency": "string",
@@ -3223,16 +3225,16 @@ components:
               "valueDate": "2022-01-31",
               "paymentType": "Complete",
               "depositedAmount": 0,
-              "totalAmount": 0,
+              "totalAmountPaid": 0,
               "capitalGainsTax": 0,
               "billNumber": "string",
               "customerNumber": "string",
-              "noticeChargeAmount": 0,
-              "defaultChargeAmount": 0,
-              "otherCostsAmount": 0,
-              "otherDefaultCostsAmount": 0,
-              "defaultInterestAmount": 0,
-              "discountAmount": 0,
+              "noticeChargeAmountPaid": 0,
+              "defaultChargeAmountPaid": 0,
+              "otherCostsAmountPaid": 0,
+              "otherDefaultCostsAmountPaid": 0,
+              "defaultInterestAmountPaid": 0,
+              "discountAmountGiven": 0,
               "currency": "string",
               "currencyExchange": {
                 "currency": "string",


### PR DESCRIPTION
Renamed the amount properties in order to better reflect their purpose. I added "Paid" and "Given" postfixes. This conforms to the already approved change of having either "Due" or "Offered" postfixes in the corresponding properties in claimDetails.

#174 