### PR TITLE
The claimId should be included exclusively in the URI to adhere to RE…

### DIFF
--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -1486,9 +1486,7 @@ components:
       description: |
         Merge patch claim object
       type: object
-      properties:
-        claimKey:
-          $ref: "#/components/schemas/claimKey"
+      properties:       
         expirationDate:
           type: string
           format: date


### PR DESCRIPTION
The claimId should be included exclusively in the URI to adhere to RESTful principles, which dictate that the URI should uniquely identify the resource to be modified. The request body should only contain the fields that are intended to be updated.
#210 