### PR TITLE
Removed extra currency property

### DIFF
--- a/Deliverables/IOBWS-Claims3.0.yaml
+++ b/Deliverables/IOBWS-Claims3.0.yaml
@@ -1831,9 +1831,6 @@ components:
         discountAmountGiven:
           description: Discount that was granted when the claim was paid.
           type: number
-        currency:
-          type: string
-          pattern: '[A-Z]{3}'
         currencyExchange:
           $ref: "#/components/schemas/currencyExchangeRate"
         transactionBatchId:
@@ -3044,7 +3041,6 @@ components:
             "otherDefaultCostsAmountPaid": 0,
             "defaultInterestAmountPaid": 0,
             "discountAmountGiven": 0,
-            "currency": "string",
             "currencyExchange": {
               "currency": "string",
               "rate": 0
@@ -3182,7 +3178,6 @@ components:
               "otherDefaultCostsAmountPaid": 0,
               "defaultInterestAmountPaid": 0,
               "discountAmountGiven": 0,
-              "currency": "string",
               "currencyExchange": {
                 "currency": "string",
                 "rate": 0


### PR DESCRIPTION
Currency property is redundant in the payment section.  Since its already in the currencyExchangeRate type