### PR TITLE
[Documents] document-store as optional query parameter with Ark default

### DIFF
--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -56,7 +56,7 @@ paths:
   # Document Service
   #####################################################
 
-  /v1/documents/{document-store}:
+  /v1/documents:
 
     post:
       summary: Upload and store new documents
@@ -69,8 +69,8 @@ paths:
         - BearerAuthOAuth: []
       parameters:
       #path
-        - $ref: "#/components/parameters/documentStore"
       #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
         #common header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -121,8 +121,8 @@ paths:
         - BearerAuthOAuth: []
       parameters:
         #path
-        - $ref: "#/components/parameters/documentStore"
         #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
         - $ref: "#/components/parameters/senderKennitalaQuery"
         - $ref: "#/components/parameters/documentsProcessIdQuery"
         - $ref: "#/components/parameters/documentTypeCode"
@@ -162,7 +162,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{document-store}/{sender-kennitala}/{documents-id}:
+  /v1/documents/{sender-kennitala}/{documents-id}:
 
     put:
       summary: Update documents
@@ -189,10 +189,10 @@ paths:
 
       parameters:
       #path
-        - $ref: "#/components/parameters/documentStore"
         - $ref: "#/components/parameters/senderKennitala"
         - $ref: "#/components/parameters/documentsId"
-      #query # NO QUERY PARAMETER
+      #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
         #mandatory header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -229,7 +229,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{document-store}/{sender-kennitala}/types:
+  /v1/documents/{sender-kennitala}/types:
 
     get:
       summary: Get list of all document types
@@ -243,9 +243,9 @@ paths:
         - BearerAuthOAuth: []
       parameters:
         #path
-        - $ref: "#/components/parameters/documentStore"
         - $ref: "#/components/parameters/senderKennitala"
         #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
         #header
           #mandatory header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -439,7 +439,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/crossreferences/{document-store}/{document-id}/{key-type}/{key}:
+  /v1/crossreferences/{document-id}/{key-type}/{key}:
 
     delete:
       summary: Delete a cross-reference
@@ -460,12 +460,12 @@ paths:
           - $ref: "#/components/parameters/Idempotency-Key"
         #path
           #mandatory path parameters
-          - $ref: "#/components/parameters/documentStorePathParameter"
           - $ref: "#/components/parameters/documentIdPathParameter"
           - $ref: "#/components/parameters/keyTypePathParameter"
           - $ref: "#/components/parameters/keyPathParameter"
           #optional path parameter NO QUERY PARAMETER
         #query
+          - $ref: "#/components/parameters/documentStoreQueryParameter"
           - $ref: "#/components/parameters/externalEventId"
 
       responses:
@@ -743,7 +743,8 @@ components:
       name: documentStore
       in: query
       description: |
-        Document data storage system. The value is one of the following:
+        Document data storage system. The value is one of the following.
+        If omitted, default value is `Ark`.
       required: false
       example: Ark
       schema:


### PR DESCRIPTION
## Related Issue
- Closes #261

## Preview
https://petstore.swagger.io/?url=https://raw.githubusercontent.com/arnarion/IST-FUT-FMTH/improvement/261-document-store-query-default-ark/Deliverables/IOBWS-Documents3.1.yaml

## Problem / Context
In the Documents API, document-store is encoded in URL paths even though this is primarily a storage selection concern and defaults to Ark in practice.

## What Changed
1. Removed document-store from path segments in affected routes.
2. Added/used optional documentStore query parameter on those routes.
3. Updated documentStore query parameter description to explicitly state default behavior: omitted means Ark.

## Impact
- API surface is cleaner and less path-coupled to storage implementation.
- Consumers can call canonical routes without including store in path.
- Non-default store behavior remains available via optional query parameter.

## Release Notes (short)
Moved document-store from path identity to optional documentStore query parameter and documented default Ark behavior.
