### PR TITLE
[Documents] Split process lifecycle routes and normalize single-process endpoints

### DIFF
--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -83,16 +83,14 @@ paths:
         $ref: "#/components/requestBodies/documentsProcessInitiation"
 
       responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentsProcessWithStatusDetails"
+        '201':
+          $ref: "#/components/responses/CREATED_201_DocumentsProcessWithStatusDetails"
         '400':
           $ref: "#/components/responses/BAD_REQUEST_400"
         '401':
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
         '405':
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
@@ -146,8 +144,6 @@ paths:
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
         '405':
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
@@ -2084,6 +2080,21 @@ components:
           schema:
             $ref: "#/components/schemas/documentsProcessWithStatusDetails"
           examples: 
+            example:
+              $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
+
+    CREATED_201_DocumentsProcessWithStatusDetails:
+      description: Documents process created
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentsProcessWithStatusDetails"
+          examples:
             example:
               $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
 

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -56,12 +56,12 @@ paths:
   # Document Service
   #####################################################
 
-  /v1/documents:
+  /v1/document-processes:
 
     post:
-      summary: Upload and store new documents
+      summary: Create document process
       description: Upload and store new documents
-      operationId: uploadDocument
+      operationId: createDocumentProcess
       tags:
         - Document Service (DS)
       security:
@@ -109,11 +109,11 @@ paths:
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
           
     get:
-      summary: Query uploaded documents processes
+      summary: Query document processes
       description: |
         Find uploaded documents process by query parameters. Only the document sender can search for the document.
         The document owner goes through the banks portal.
-      operationId: searchForDocumentsProcess
+      operationId: searchForDocumentProcesses
       tags:
         - Document Service (DS)
       security:
@@ -124,7 +124,6 @@ paths:
         #query
         - $ref: "#/components/parameters/documentStoreQueryParameter"
         - $ref: "#/components/parameters/senderKennitalaQuery"
-        - $ref: "#/components/parameters/documentsProcessIdQuery"
         - $ref: "#/components/parameters/documentTypeCode"
         - $ref: "#/components/parameters/status"
         - $ref: "#/components/parameters/dateFrom"
@@ -162,13 +161,56 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{sender-kennitala}/{documents-id}:
+  /v1/document-processes/{document-process-id}:
+
+    get:
+      summary: Get document process by ID
+      description: |
+        Retrieve a single document process by its ID.
+      operationId: getDocumentProcess
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+      #path
+        - $ref: "#/components/parameters/documentProcessId"
+      #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+      #header
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentsProcessWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
     put:
       summary: Update documents
       description: |
         Update documents if the document type allows it. User can choose to only send new or changed files
-      operationId: update
+      operationId: updateDocumentProcess
       tags:
         - Document Service (DS)
 
@@ -189,8 +231,7 @@ paths:
 
       parameters:
       #path
-        - $ref: "#/components/parameters/senderKennitala"
-        - $ref: "#/components/parameters/documentsId"
+        - $ref: "#/components/parameters/documentProcessId"
       #query
         - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
@@ -547,24 +588,15 @@ components:
       required: false
       example: 192.168.8.78
 
-    documentsId:
-      name: documents-id
+    documentProcessId:
+      name: document-process-id
       in: path
       description: |
-        Document id in path
+        Document process id in path
       required: true
       schema:
         $ref: "#/components/schemas/uuid"
         
-    documentsProcessIdQuery:
-      name: documentsProcessId
-      in: query
-      description: |
-        Documents process id.
-      required: false
-      schema:
-        $ref: "#/components/schemas/uuid"
-
     documentStore:
       name: document-store
       description: |

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1023,6 +1023,7 @@ components:
         - id
         - receiverKennitala
         - status
+        - isCrossReferenced
       properties:
         id:
           $ref: "#/components/schemas/uuid"
@@ -1049,6 +1050,10 @@ components:
           description: Process status message
           type: string
           maxLength: 250
+        isCrossReferenced:
+          description: |
+            Indicates whether the document is cross-referenced to another object.
+          type: boolean
 
     documentsProcessWithStatusDetails:
       description: |
@@ -2416,7 +2421,8 @@ components:
               "receiverKennitala": "1111112239",
               "fileType": "PDF",
               "status": "received",
-              "statusMessage": "File is currently being processed"
+              "statusMessage": "File is currently being processed",
+              "isCrossReferenced": true
             },
             {
               "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
@@ -2424,7 +2430,8 @@ components:
               "receiverKennitala": "1111112249",
               "fileType": "PDF",
               "status": "received",
-              "statusMessage": "File is currently being processed"
+              "statusMessage": "File is currently being processed",
+              "isCrossReferenced": false
             }
           ]
         }
@@ -2448,7 +2455,8 @@ components:
                   "receiverKennitala": "1111112239",
                   "fileType": "PDF",
                   "status": "received",
-                  "statusMessage": "File is currently being processed"
+                  "statusMessage": "File is currently being processed",
+                  "isCrossReferenced": true
                 },
                 {
                   "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
@@ -2456,7 +2464,8 @@ components:
                   "receiverKennitala": "1111112249",
                   "fileType": "PDF",
                   "status": "received",
-                  "statusMessage": "File is currently being processed"
+                  "statusMessage": "File is currently being processed",
+                  "isCrossReferenced": false
                 }
               ]
             }

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -56,7 +56,7 @@ paths:
   # Document Service
   #####################################################
 
-  /v1/documents/{document-store}:
+  /v1/documents:
 
     post:
       summary: Upload and store new documents
@@ -69,8 +69,8 @@ paths:
         - BearerAuthOAuth: []
       parameters:
       #path
-        - $ref: "#/components/parameters/documentStore"
       #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
         #common header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -121,8 +121,8 @@ paths:
         - BearerAuthOAuth: []
       parameters:
         #path
-        - $ref: "#/components/parameters/documentStore"
         #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
         - $ref: "#/components/parameters/senderKennitalaQuery"
         - $ref: "#/components/parameters/documentsProcessIdQuery"
         - $ref: "#/components/parameters/documentTypeCode"
@@ -162,7 +162,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{document-store}/{sender-kennitala}/{documents-id}:
+  /v1/documents/{sender-kennitala}/{documents-id}:
 
     put:
       summary: Update documents
@@ -189,10 +189,10 @@ paths:
 
       parameters:
       #path
-        - $ref: "#/components/parameters/documentStore"
         - $ref: "#/components/parameters/senderKennitala"
         - $ref: "#/components/parameters/documentsId"
-      #query # NO QUERY PARAMETER
+      #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
         #mandatory header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -229,7 +229,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{document-store}/{sender-kennitala}/types:
+  /v1/documents/{sender-kennitala}/types:
 
     get:
       summary: Get list of all document types
@@ -243,9 +243,9 @@ paths:
         - BearerAuthOAuth: []
       parameters:
         #path
-        - $ref: "#/components/parameters/documentStore"
         - $ref: "#/components/parameters/senderKennitala"
         #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
         #header
           #mandatory header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -439,7 +439,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/crossreferences/{document-store}/{document-id}/{key-type}/{key}:
+  /v1/crossreferences/{document-id}/{key-type}/{key}:
 
     delete:
       summary: Delete a cross-reference
@@ -460,12 +460,12 @@ paths:
           - $ref: "#/components/parameters/Idempotency-Key"
         #path
           #mandatory path parameters
-          - $ref: "#/components/parameters/documentStorePathParameter"
           - $ref: "#/components/parameters/documentIdPathParameter"
           - $ref: "#/components/parameters/keyTypePathParameter"
           - $ref: "#/components/parameters/keyPathParameter"
           #optional path parameter NO QUERY PARAMETER
         #query
+          - $ref: "#/components/parameters/documentStoreQueryParameter"
           - $ref: "#/components/parameters/externalEventId"
 
       responses:
@@ -743,7 +743,8 @@ components:
       name: documentStore
       in: query
       description: |
-        Document data storage system. The value is one of the following:
+        Document data storage system. The value is one of the following.
+        If omitted, default value is `Ark`.
       required: false
       example: Ark
       schema:


### PR DESCRIPTION
## Related Issues
- Closes #271
- Closes #272
- Closes #263
- Closes #280
- Closes #281

## Summary
This PR separates document-process lifecycle routes from document-oriented paths, introduces canonical single-process operations by process ID, aligns process identity naming, and exposes cross-reference status directly in file status payloads.

## Changes
- Moved process collection lifecycle endpoints from `/v1/documents` to `/v1/document-processes`:
  - `POST /v1/document-processes`
  - `GET /v1/document-processes`
- Removed `documentsProcessId` from process collection query filtering
- Replaced legacy over-specified process update route with canonical process item route:
  - `PUT /v1/document-processes/{document-process-id}`
- Added single-process retrieval endpoint:
  - `GET /v1/document-processes/{document-process-id}`
- Applied process ID naming consistency (Issue 13 scope):
  - path parameter component renamed to `documentProcessId`
  - path parameter name renamed to `document-process-id`
  - path parameter description updated to process identity wording
- Included Issue 1 prerequisite change by cherry-picking commit from `improvement/261-document-store-query-default-ark` (document store as optional query with default behavior)
- Added Issue 8 response payload field:
  - `files[*].isCrossReferenced` in file status responses
  - updated process status response examples accordingly

## OpenAPI Preview
https://petstore.swagger.io/?url=https://raw.githubusercontent.com/arnarion/IST-FUT-FMTH/improvement/271-272-document-process-resource-model/Deliverables/IOBWS-Documents3.1.yaml
