### PR TITLE
[Documents] Add first-class document list and retrieval endpoints

### DIFF
--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -83,16 +83,14 @@ paths:
         $ref: "#/components/requestBodies/documentsProcessInitiation"
 
       responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentsProcessWithStatusDetails"
+        '201':
+          $ref: "#/components/responses/CREATED_201_DocumentsProcessWithStatusDetails"
         '400':
           $ref: "#/components/responses/BAD_REQUEST_400"
         '401':
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
         '405':
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
@@ -146,8 +144,6 @@ paths:
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
         '405':
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
@@ -2084,6 +2080,21 @@ components:
           schema:
             $ref: "#/components/schemas/documentsProcessWithStatusDetails"
           examples: 
+            example:
+              $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
+
+    CREATED_201_DocumentsProcessWithStatusDetails:
+      description: Documents process created
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentsProcessWithStatusDetails"
+          examples:
             example:
               $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
 

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -56,12 +56,12 @@ paths:
   # Document Service
   #####################################################
 
-  /v1/documents:
+  /v1/document-processes:
 
     post:
-      summary: Upload and store new documents
+      summary: Create document process
       description: Upload and store new documents
-      operationId: uploadDocument
+      operationId: createDocumentProcess
       tags:
         - Document Service (DS)
       security:
@@ -109,11 +109,11 @@ paths:
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
           
     get:
-      summary: Query uploaded documents processes
+      summary: Query document processes
       description: |
         Find uploaded documents process by query parameters. Only the document sender can search for the document.
         The document owner goes through the banks portal.
-      operationId: searchForDocumentsProcess
+      operationId: searchForDocumentProcesses
       tags:
         - Document Service (DS)
       security:
@@ -124,7 +124,6 @@ paths:
         #query
         - $ref: "#/components/parameters/documentStoreQueryParameter"
         - $ref: "#/components/parameters/senderKennitalaQuery"
-        - $ref: "#/components/parameters/documentsProcessIdQuery"
         - $ref: "#/components/parameters/documentTypeCode"
         - $ref: "#/components/parameters/status"
         - $ref: "#/components/parameters/dateFrom"
@@ -162,13 +161,56 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{sender-kennitala}/{documents-id}:
+  /v1/document-processes/{document-process-id}:
+
+    get:
+      summary: Get document process by ID
+      description: |
+        Retrieve a single document process by its ID.
+      operationId: getDocumentProcess
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+      #path
+        - $ref: "#/components/parameters/documentProcessId"
+      #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+      #header
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentsProcessWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
     put:
       summary: Update documents
       description: |
         Update documents if the document type allows it. User can choose to only send new or changed files
-      operationId: update
+      operationId: updateDocumentProcess
       tags:
         - Document Service (DS)
 
@@ -189,8 +231,7 @@ paths:
 
       parameters:
       #path
-        - $ref: "#/components/parameters/senderKennitala"
-        - $ref: "#/components/parameters/documentsId"
+        - $ref: "#/components/parameters/documentProcessId"
       #query
         - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
@@ -547,24 +588,15 @@ components:
       required: false
       example: 192.168.8.78
 
-    documentsId:
-      name: documents-id
+    documentProcessId:
+      name: document-process-id
       in: path
       description: |
-        Document id in path
+        Document process id in path
       required: true
       schema:
         $ref: "#/components/schemas/uuid"
         
-    documentsProcessIdQuery:
-      name: documentsProcessId
-      in: query
-      description: |
-        Documents process id.
-      required: false
-      schema:
-        $ref: "#/components/schemas/uuid"
-
     documentStore:
       name: document-store
       description: |

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1023,6 +1023,7 @@ components:
         - id
         - receiverKennitala
         - status
+        - isCrossReferenced
       properties:
         id:
           $ref: "#/components/schemas/uuid"
@@ -1049,6 +1050,10 @@ components:
           description: Process status message
           type: string
           maxLength: 250
+        isCrossReferenced:
+          description: |
+            Indicates whether the document is cross-referenced to another object.
+          type: boolean
 
     documentsProcessWithStatusDetails:
       description: |
@@ -2416,7 +2421,8 @@ components:
               "receiverKennitala": "1111112239",
               "fileType": "PDF",
               "status": "received",
-              "statusMessage": "File is currently being processed"
+              "statusMessage": "File is currently being processed",
+              "isCrossReferenced": true
             },
             {
               "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
@@ -2424,7 +2430,8 @@ components:
               "receiverKennitala": "1111112249",
               "fileType": "PDF",
               "status": "received",
-              "statusMessage": "File is currently being processed"
+              "statusMessage": "File is currently being processed",
+              "isCrossReferenced": false
             }
           ]
         }
@@ -2448,7 +2455,8 @@ components:
                   "receiverKennitala": "1111112239",
                   "fileType": "PDF",
                   "status": "received",
-                  "statusMessage": "File is currently being processed"
+                  "statusMessage": "File is currently being processed",
+                  "isCrossReferenced": true
                 },
                 {
                   "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
@@ -2456,7 +2464,8 @@ components:
                   "receiverKennitala": "1111112249",
                   "fileType": "PDF",
                   "status": "received",
-                  "statusMessage": "File is currently being processed"
+                  "statusMessage": "File is currently being processed",
+                  "isCrossReferenced": false
                 }
               ]
             }

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -56,7 +56,7 @@ paths:
   # Document Service
   #####################################################
 
-  /v1/documents/{document-store}:
+  /v1/documents:
 
     post:
       summary: Upload and store new documents
@@ -69,8 +69,8 @@ paths:
         - BearerAuthOAuth: []
       parameters:
       #path
-        - $ref: "#/components/parameters/documentStore"
       #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
         #common header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -121,8 +121,8 @@ paths:
         - BearerAuthOAuth: []
       parameters:
         #path
-        - $ref: "#/components/parameters/documentStore"
         #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
         - $ref: "#/components/parameters/senderKennitalaQuery"
         - $ref: "#/components/parameters/documentsProcessIdQuery"
         - $ref: "#/components/parameters/documentTypeCode"
@@ -162,7 +162,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{document-store}/{sender-kennitala}/{documents-id}:
+  /v1/documents/{sender-kennitala}/{documents-id}:
 
     put:
       summary: Update documents
@@ -189,10 +189,10 @@ paths:
 
       parameters:
       #path
-        - $ref: "#/components/parameters/documentStore"
         - $ref: "#/components/parameters/senderKennitala"
         - $ref: "#/components/parameters/documentsId"
-      #query # NO QUERY PARAMETER
+      #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
       #header
         #mandatory header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -229,7 +229,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{document-store}/{sender-kennitala}/types:
+  /v1/documents/{sender-kennitala}/types:
 
     get:
       summary: Get list of all document types
@@ -243,9 +243,9 @@ paths:
         - BearerAuthOAuth: []
       parameters:
         #path
-        - $ref: "#/components/parameters/documentStore"
         - $ref: "#/components/parameters/senderKennitala"
         #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
         #header
           #mandatory header parameter
         - $ref: "#/components/parameters/X-Request-ID"
@@ -439,7 +439,7 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/crossreferences/{document-store}/{document-id}/{key-type}/{key}:
+  /v1/crossreferences/{document-id}/{key-type}/{key}:
 
     delete:
       summary: Delete a cross-reference
@@ -460,12 +460,12 @@ paths:
           - $ref: "#/components/parameters/Idempotency-Key"
         #path
           #mandatory path parameters
-          - $ref: "#/components/parameters/documentStorePathParameter"
           - $ref: "#/components/parameters/documentIdPathParameter"
           - $ref: "#/components/parameters/keyTypePathParameter"
           - $ref: "#/components/parameters/keyPathParameter"
           #optional path parameter NO QUERY PARAMETER
         #query
+          - $ref: "#/components/parameters/documentStoreQueryParameter"
           - $ref: "#/components/parameters/externalEventId"
 
       responses:
@@ -743,7 +743,8 @@ components:
       name: documentStore
       in: query
       description: |
-        Document data storage system. The value is one of the following:
+        Document data storage system. The value is one of the following.
+        If omitted, default value is `Ark`.
       required: false
       example: Ark
       schema:

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -266,6 +266,99 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
+  /v1/documents:
+
+    get:
+      summary: Query documents
+      description: |
+        Query documents. Returns document/file status entries matching filters.
+      operationId: searchForDocuments
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/ownerKennitalaQuery"
+        - $ref: "#/components/parameters/documentTypeCode"
+        - $ref: "#/components/parameters/dateFrom"
+        - $ref: "#/components/parameters/dateTo"
+        - $ref: "#/components/parameters/pageOptional"
+        - $ref: "#/components/parameters/itemsPerPageOptional"
+        #header
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentListWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/documents/{document-id}:
+
+    get:
+      summary: Get document by ID
+      description: |
+        Retrieve a single document/file status entry by document ID.
+      operationId: getDocument
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        #path
+        - $ref: "#/components/parameters/documentIdPathParameter"
+        #query
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/ownerKennitalaRequiredQuery"
+        #header
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
   /v1/documents/{sender-kennitala}/types:
 
     get:
@@ -663,6 +756,24 @@ components:
       in: path
       description: |
         Kennitala of the documents sender.
+      required: true
+      schema:
+        $ref: "#/components/schemas/kennitala"
+
+    ownerKennitalaQuery:
+      name: ownerKennitala
+      in: query
+      description: |
+        Kennitala of the document owner for filtering.
+      required: false
+      schema:
+        $ref: "#/components/schemas/kennitala"
+
+    ownerKennitalaRequiredQuery:
+      name: ownerKennitala
+      in: query
+      description: |
+        Kennitala of the document owner.
       required: true
       schema:
         $ref: "#/components/schemas/kennitala"
@@ -1098,6 +1209,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/documentsProcessWithStatusDetails"
+
+    documentWithStatusList:
+      description: |
+        List of document/file entries with status details.
+      type: array
+      items:
+        $ref: "#/components/schemas/fileWithStatusDetails"
 
     uuid:
       description: Unique Identifier 
@@ -2109,7 +2227,47 @@ components:
             $ref: "#/components/schemas/documentsProcessWithStatusDetails"
           examples: 
             example:
-              $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
+            $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
+
+    OK_200_DocumentWithStatusDetails:
+      description: Get document details
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/fileWithStatusDetails"
+
+    OK_200_DocumentListWithStatusDetails:
+      description: Get document list details
+      headers:
+        X-Paging-CurrentPage:
+          description: |
+            Current page number
+          schema:
+            type: integer
+        X-Paging-TotalPages:
+          description: |
+            Total pages
+          schema:
+            type: integer
+        X-Paging-TotalItems:
+          description: |
+            Total items
+          schema:
+            type: integer
+        X-Paging-PerPage:
+          description: |
+            Items per page
+          schema:
+            type: integer
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentWithStatusList"
 
     OK_200_DocumentTypeDetails:
       description: OK


### PR DESCRIPTION
## Related Issues
- Closes #274

## Summary
This PR introduces first-class document resource endpoints for list/filter and single-document retrieval.

## Changes
- Added document list endpoint:
  - `GET /v1/documents`
- Added single-document endpoint:
  - `GET /v1/documents/{document-id}`
- Added owner filtering parameters:
  - optional `ownerKennitala` for document list
  - required `ownerKennitala` for single-document retrieval
- Added reusable response components for document list/detail responses
- Added reusable `documentWithStatusList` schema for document list payloads
- Added pagination response headers to document list response (`X-Paging-CurrentPage`, `X-Paging-TotalPages`, `X-Paging-TotalItems`, `X-Paging-PerPage`)

## Notes
- This branch is intentionally based on `improvement/271-272-document-process-resource-model` and includes prerequisite commits needed for coherent routing/model evolution.
- PR target is `master`.

## OpenAPI Preview
https://petstore.swagger.io/?url=https://raw.githubusercontent.com/arnarion/IST-FUT-FMTH/improvement/274-document-query-retrieval/Deliverables/IOBWS-Documents3.1.yaml
