### PR TITLE
[Documents] Harmonize HTTP status semantics for document endpoints

### DIFF
--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -83,16 +83,14 @@ paths:
         $ref: "#/components/requestBodies/documentsProcessInitiation"
 
       responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentsProcessWithStatusDetails"
+        '201':
+          $ref: "#/components/responses/CREATED_201_DocumentsProcessWithStatusDetails"
         '400':
           $ref: "#/components/responses/BAD_REQUEST_400"
         '401':
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
         '405':
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
@@ -147,8 +145,6 @@ paths:
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
         '405':
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
@@ -2046,6 +2042,21 @@ components:
           schema:
             $ref: "#/components/schemas/documentsProcessWithStatusDetails"
           examples: 
+            example:
+              $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
+
+    CREATED_201_DocumentsProcessWithStatusDetails:
+      description: Documents process created
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentsProcessWithStatusDetails"
+          examples:
             example:
               $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
 


### PR DESCRIPTION
## Summary
Harmonizes HTTP response status semantics for document collection/create endpoints.

## Related issues
- Closes #281

## Changes
- Changes `POST /v1/documents/{document-store}` success response from `200` to `201`
- Adds reusable `CREATED_201_DocumentsProcessWithStatusDetails` response component
- Ensures `Location` header is included for document creation `201` response
- Removes `404` from:
  - `POST /v1/documents/{document-store}`
  - `GET /v1/documents/{document-store}`

## OpenAPI preview
- https://petstore.swagger.io/?url=https://raw.githubusercontent.com/arnarion/IST-FUT-FMTH/improvement/281-document-endpoint-status-semantics/Deliverables/IOBWS-Documents3.1.yaml
