### PR TITLE
Fixes and adjustments to Documents API overhaul

### DIFF
--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1750,12 +1750,12 @@ components:
         - "SERVICE_UNAVAILABLE"
 
     #####################################################
-    # RFC7807 Error Schemas
+    # Error Schemas
     #####################################################
 
     Error400:
       description: |
-        Error information according to [RFC7807] for HTTP error code 400.
+        Error information for HTTP error code 400.
         Uses oneOf to distinguish between format errors and validation errors.
       oneOf:
         - $ref: "#/components/schemas/FormatError"
@@ -1870,7 +1870,7 @@ components:
 
     Error401:
       description: |
-        Standardised definition of reporting error information according to [RFC7807]
+        Standardised definition of reporting error information
         in case of a HTTP error code 401.
       type: object
       required:
@@ -1902,7 +1902,7 @@ components:
 
     Error403:
       description: |
-        Standardised definition of reporting error information according to [RFC7807]
+        Standardised definition of reporting error information
         in case of a HTTP error code 403.
       type: object
       required:
@@ -1934,7 +1934,7 @@ components:
 
     Error404:
       description: |
-        Standardised definition of reporting error information according to [RFC7807]
+        Standardised definition of reporting error information
         in case of a HTTP error code 404.
       type: object
       required:
@@ -1966,7 +1966,7 @@ components:
 
     Error429:
       description: |
-        Standardised definition of reporting error information according to [RFC7807]
+        Standardised definition of reporting error information
         in case of a HTTP error code 429.
       type: object
       required:
@@ -1998,7 +1998,7 @@ components:
 
     Error500:
       description: |
-        Standardised definition of reporting error information according to [RFC7807]
+        Standardised definition of reporting error information
         in case of a HTTP error code 500.
       type: object
       required:
@@ -2030,7 +2030,7 @@ components:
 
     Error503:
       description: |
-        Standardised definition of reporting error information according to [RFC7807]
+        Standardised definition of reporting error information
         in case of a HTTP error code 503.
       type: object
       required:

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -781,7 +781,7 @@ components:
       name: dateTo
       in: query
       description: |
-        End date (inclusive) of the expected list, default is "now" if not given.
+        End date (inclusive) of the expected list.
       required: false
       example: "2024-11-30"
       schema:

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1023,30 +1023,22 @@ components:
 
     documentTypeDetails:
       description: |
-        Document type details.
+        Document type details as returned by the service.
       type: object
       required:
         - code
-        - name
-        - durableMedia
+        - description
+        - fileName
+        - email
       properties:
         code:
           description: Unique code for the document type.
           type: string
           minLength: 1
           maxLength: 10
-        name:
-          description: Short description for the document type
-          type: string
-          maxLength: 70
-        durableMedia:
-          description: |
-            Control flag describing if document type is durable media. If document type
-            is durable media then any batch using this code can not be updated.
-          type: boolean
         description:
           description: |
-            Long description for the document
+            Description of the document type.
           type: string
           maxLength: 140
         fileType:
@@ -1056,23 +1048,54 @@ components:
           enum:
             - "XML"
             - "PDF"
-        categoryCode:
+        fileName:
           description: |
-            Document category code.
-          allOf:
-            - $ref: "#/components/schemas/documentCategory"
-        categoryDescription:
-          description: |
-            Human-readable description of the document category.
+            File name for FTP delivery of data for this document type.
           type: string
           maxLength: 140
+        email:
+          description: |
+            Email address of the submitting party for this document type.
+          type: string
+          format: email
+        category:
+          description: |
+            Category information for this document type.
+          type: object
+          required:
+            - code
+            - description
+          properties:
+            code:
+              $ref: "#/components/schemas/documentCategory"
+            description:
+              description: Category description.
+              type: string
+              maxLength: 140
+            subCode:
+              description: Sub-category code. Generally not in use.
+              type: string
+            name:
+              description: Category name.
+              type: string
+              maxLength: 140
 
     documentTypeList:
       description: |
-        List of document type with details.
-      type: array
-      items:
-        $ref: "#/components/schemas/documentTypeDetails"
+        Document types for a sender.
+      type: object
+      required:
+        - senderName
+        - documentTypes
+      properties:
+        senderName:
+          description: Name of the sender.
+          type: string
+          maxLength: 140
+        documentTypes:
+          type: array
+          items:
+            $ref: "#/components/schemas/documentTypeDetails"
 
     documentTypeCreation:
       description: |
@@ -2646,28 +2669,34 @@ components:
     #####################################################
     
     documentTypeListResponse-200_json_Example:
-      description: List of document types.
+      description: List of document types for a sender.
       value:
-        [
-          { 
-            "code": "HMTDL",
-            "name": "Launaseðlar",
-            "durableMedia": true,
-            "description": "Launaseðlar - Hólmfríður ÞÍ Traustadóttir",
-            "fileType": "XML",
-            "categoryCode": "Payslip",
-            "categoryDescription": "Payslips"
-          },
-          { 
-            "code": "HMTDR",
-            "name": "Reikningar",
-            "durableMedia": true,
-            "description": "Reikningar - Hólmfríður ÞÍ Traustadóttir",
-            "fileType": "PDF",
-            "categoryCode": "Bill",
-            "categoryDescription": "Bills"
-          }
-        ]
+        {
+          "senderName": "Hólmfríður ÞÍ Traustadóttir",
+          "documentTypes": [
+            { 
+              "code": "HMTDL",
+              "description": "Launaseðlar - Hólmfríður ÞÍ Traustadóttir",
+              "fileType": "XML",
+              "fileName": "HMTDL_launasedlar.xml",
+              "category": {
+                "code": "Payslip",
+                "description": "Launaseðlar"
+              }
+            },
+            { 
+              "code": "HMTDR",
+              "description": "Reikningar - Hólmfríður ÞÍ Traustadóttir",
+              "fileType": "PDF",
+              "fileName": "HMTDR_reikningar.pdf",
+              "email": "billing@example.com",
+              "category": {
+                "code": "Bill",
+                "description": "Reikningar"
+              }
+            }
+          ]
+        }
 
     documentCreated-201_json_Example:
       description: Document created response.
@@ -2683,12 +2712,13 @@ components:
           "created": [
             {
               "code": "HMTDT",
-              "name": "Tilkynningar",
-              "durableMedia": false,
               "description": "Tilkynningar - Hólmfríður ÞÍ Traustadóttir",
               "fileType": "XML",
-              "categoryCode": "Notification",
-              "categoryDescription": "Tilkynningar"
+              "fileName": "HMTDT_tilkynningar.xml",
+              "category": {
+                "code": "Notification",
+                "description": "Tilkynningar"
+              }
             }
           ],
           "failed": [

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1267,6 +1267,10 @@ components:
         file:
           description: XML document payload as a plain string.
           type: string
+        styleSheetName:
+          description: |
+            Name of the XSLT style sheet to apply when rendering the XML document.
+          type: string
 
     filePayloadPDF:
       type: object

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1124,24 +1124,32 @@ components:
             - "PDF"
         categoryCode:
           $ref: "#/components/schemas/documentCategory"
-        submittingId:
-          description: |
-            Identifier (kennitala) of the submitting party authorised to send documents on behalf of the sender.
-          allOf:
-            - $ref: "#/components/schemas/kennitala"
         email:
           description: |
             Email address associated with this document type.
           type: string
           format: email
 
-    documentTypeCreationList:
+    documentTypeCreationRequest:
       description: |
-        List of document types to create.
-      type: array
-      minItems: 1
-      items:
-        $ref: "#/components/schemas/documentTypeCreation"
+        Request body for creating document types for a sender.
+      type: object
+      required:
+        - documentTypes
+      properties:
+        submittingId:
+          description: |
+            Identifier (kennitala) of the submitting party authorised to send documents on behalf of the sender.
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/kennitala"
+        documentTypes:
+          description: |
+            List of document types to create.
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/documentTypeCreation"
 
     documentTypeCreationFailure:
       description: |
@@ -2187,7 +2195,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentTypeCreationList"
+            $ref: "#/components/schemas/documentTypeCreationRequest"
           examples:
             example:
               $ref: "#/components/examples/createDocumentTypes_json_Example"
@@ -2747,17 +2755,20 @@ components:
     createDocumentTypes_json_Example:
       description: Document types creation request.
       value:
-        [
-          {
-            "fileType": "PDF",
-            "categoryCode": "Bill"
-          },
-          {
-            "fileType": "XML",
-            "categoryCode": "Notification",
-            "email": "notifications@example.com"
-          }
-        ]
+        {
+          "submittingId": "1909791489",
+          "documentTypes": [
+            {
+              "fileType": "PDF",
+              "categoryCode": "Bill"
+            },
+            {
+              "fileType": "XML",
+              "categoryCode": "Notification",
+              "email": "notifications@example.com"
+            }
+          ]
+        }
 
     documentInitiation_pdf_Example:
       description: Single PDF document creation request.

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1091,6 +1091,11 @@ components:
             - "PDF"
         categoryCode:
           $ref: "#/components/schemas/documentCategory"
+        submittingId:
+          description: |
+            Identifier (kennitala) of the submitting party authorised to send documents on behalf of the sender.
+          allOf:
+            - $ref: "#/components/schemas/kennitala"
         email:
           description: |
             Email address associated with this document type.

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -423,7 +423,9 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-    delete:
+  /v1/crossreferences/bulk-delete:
+
+    post:
       summary: Delete cross-references
       description: |
         Deletes an array of cross-references. Each item identifies a cross-reference

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -186,6 +186,7 @@ paths:
         - $ref: "#/components/parameters/Storage-System"
         - $ref: "#/components/parameters/senderIdOptionalQuery"
         - $ref: "#/components/parameters/ownerIdQuery"
+        - $ref: "#/components/parameters/externalIdQuery"
         - $ref: "#/components/parameters/documentTypeCode"
         - $ref: "#/components/parameters/batchStatusQuery"
         - $ref: "#/components/parameters/dateFrom"
@@ -842,6 +843,15 @@ components:
         type: string
         minLength: 1
         maxLength: 10
+
+    externalIdQuery:
+      name: externalId
+      in: query
+      description: |
+        External identifier used to link the document with the sender's own systems.
+      required: false
+      schema:
+        type: string
 
     batchStatusQuery:
       name: status

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -5,7 +5,7 @@ info:
   description: |
     # Summary
     
-    This document represents version 3.0 of the Icelandic Online Banking Services (IOBWS)
+    This document represents version 3.1 of the Icelandic Online Banking Services (IOBWS)
     and is released as a part of the technical specification ÍST TS 314, digital documents, 
     by the Icelandic Standards Council.
     Previous versions of IOBWS, released in 2007 and 2013 respectively, each used the then most recent OASIS SOAP standards.
@@ -20,9 +20,9 @@ info:
 
     The definition of UTF-8 strings in context of this API has to support at least the following characters
 
-    a b c d e f g h i j k l m n o p q r s t u v w x y z å ä ö æ ø á ð é í ó ú ý	þ	æ	ö
+    a b c d e f g h i j k l m n o p q r s t u v w x y z å ä ö æ ø á ð é í ó ú ý þ
     
-    A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Å Ä Ö Æ Ø Á Ð É Í Ó Ú Ý	Þ	Æ	Ö
+    A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Å Ä Ö Æ Ø Á Ð É Í Ó Ú Ý Þ
 
     0 1 2 3 4 5 6 7 8 9
      
@@ -56,32 +56,106 @@ paths:
   # Document Service
   #####################################################
 
-  /v1/documents/{document-store}:
+  /v1/document-processes:
 
     post:
-      summary: Upload and store new documents
-      description: Upload and store new documents
-      operationId: uploadDocument
+      summary: Create a document process
+      description: |
+        Creates a new document process and uploads one or more documents.
+      operationId: createDocumentProcess
       tags:
         - Document Service (DS)
       security:
         - {}
         - BearerAuthOAuth: []
       parameters:
-      #path
-        - $ref: "#/components/parameters/documentStore"
-      #query
-      #header
-        #common header parameter
         - $ref: "#/components/parameters/X-Request-ID"
-        #mandatory header parameter
-        #optional header parameters
         - $ref: "#/components/parameters/USR-IP-Address_optional"
         - $ref: "#/components/parameters/Idempotency-Key"
-
       requestBody:
         $ref: "#/components/requestBodies/documentsProcessInitiation"
+      responses:
+        '201':
+          $ref: "#/components/responses/CREATED_201_DocumentsProcessWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '409':
+          $ref: "#/components/responses/CONFLICT_409"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
+    get:
+      summary: Search document processes
+      description: |
+        Returns a filtered list of document processes.
+      operationId: searchDocumentProcesses
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/senderKennitalaQuery"
+        - $ref: "#/components/parameters/documentTypeCode"
+        - $ref: "#/components/parameters/status"
+        - $ref: "#/components/parameters/dateFrom"
+        - $ref: "#/components/parameters/dateTo"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentsProcessListWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/document-processes/{document-process-id}:
+
+    get:
+      summary: Get a single document process
+      description: |
+        Returns a single document process by process identifier.
+      operationId: getDocumentProcessById
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/documentProcessIdPath"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
       responses:
         '200':
           $ref: "#/components/responses/OK_200_DocumentsProcessWithStatusDetails"
@@ -97,112 +171,29 @@ paths:
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
           $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
           $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
         '500':
           $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-          
-    get:
-      summary: Query uploaded documents processes
-      description: |
-        Find uploaded documents process by query parameters. Only the document sender can search for the document.
-        The document owner goes through the banks portal.
-      operationId: searchForDocumentsProcess
-      tags:
-        - Document Service (DS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        #path
-        - $ref: "#/components/parameters/documentStore"
-        #query
-        - $ref: "#/components/parameters/senderKennitalaQuery"
-        - $ref: "#/components/parameters/documentsProcessIdQuery"
-        - $ref: "#/components/parameters/documentTypeCode"
-        - $ref: "#/components/parameters/status"
-        - $ref: "#/components/parameters/dateFrom"
-        - $ref: "#/components/parameters/dateTo"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/itemsPerPage"
-        #header
-          #mandatory header parameter
-        - $ref: "#/components/parameters/X-Request-ID"
-          #optional header parameters
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-        #NO REQUEST BODY
-
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentsProcessListWithStatusDetails"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
-  /v1/documents/{document-store}/{sender-kennitala}/{documents-id}:
 
     put:
-      summary: Update documents
+      summary: Replace a document process
       description: |
-        Update documents if the document type allows it. User can choose to only send new or changed files
-      operationId: update
+        Replaces the document process resource. The request body represents the full desired state of the process.
+      operationId: replaceDocumentProcess
       tags:
         - Document Service (DS)
-
       security:
-      #####################################################
-      # REMARKS ON SECURITY IN THIS OPENAPI FILE
-      # In this file only the basic security element to transport
-      # the bearer token of an OAuth2 process, which has to
-      # be included in the HTTP header is described.
-      #
-      # WARNING:
-      # If you want to use this file for a productive implementation,
-      # it is recommended to adjust the security schemes according to
-      # your system environments and security policies.
-      #####################################################
         - {}
         - BearerAuthOAuth: []
-
       parameters:
-      #path
-        - $ref: "#/components/parameters/documentStore"
-        - $ref: "#/components/parameters/senderKennitala"
-        - $ref: "#/components/parameters/documentsId"
-      #query # NO QUERY PARAMETER
-      #header
-        #mandatory header parameter
+        - $ref: "#/components/parameters/documentProcessIdPath"
         - $ref: "#/components/parameters/X-Request-ID"
-        #optional header parameters
         - $ref: "#/components/parameters/USR-IP-Address_optional"
-        #NO REQUEST BODY
-
       requestBody:
         $ref: "#/components/requestBodies/documentsProcessInitiation"
-
       responses:
         '200':
           $ref: "#/components/responses/OK_200_UpdateDocumentsProcess"
@@ -229,30 +220,108 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/documents/{document-store}/{sender-kennitala}/types:
+  /v1/documents/{document-id}:
 
     get:
-      summary: Get list of all document types
+      summary: Get a single document
       description: |
-        Get list of all document types. Document types control if document can be updated
-      operationId: getDocumentTypeList
+        Returns a single document by identifier. If not specified, the implementation may assume the default document store (e.g. Ark).
+      operationId: getDocumentById
       tags:
         - Document Service (DS)
       security:
         - {}
         - BearerAuthOAuth: []
       parameters:
-        #path
-        - $ref: "#/components/parameters/documentStore"
-        - $ref: "#/components/parameters/senderKennitala"
-        #query
-        #header
-          #mandatory header parameter
+        - $ref: "#/components/parameters/documentIdPathParameter"
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/ownerKennitalaRequiredQuery"
         - $ref: "#/components/parameters/X-Request-ID"
-          #optional header parameters
         - $ref: "#/components/parameters/USR-IP-Address_optional"
-        #NO REQUEST BODY
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
+  /v1/documents:
+
+    get:
+      summary: Search documents
+      description: |
+        Returns a filtered list of documents. Use `GET /v1/documents/{document-id}` for retrieval of a single document by identifier.
+      operationId: searchDocuments
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/senderKennitalaQuery"
+        - $ref: "#/components/parameters/ownerKennitalaQuery"
+        - $ref: "#/components/parameters/documentTypeCode"
+        - $ref: "#/components/parameters/status"
+        - $ref: "#/components/parameters/dateFrom"
+        - $ref: "#/components/parameters/dateTo"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentListWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/document-senders/{sender-kennitala}/document-types:
+
+    get:
+      summary: Get list of all document types
+      description: |
+        Returns the document types available for a specific sender.
+      operationId: getDocumentTypesForSender
+      tags:
+        - Document Service (DS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/senderKennitala"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
       responses:
         '200':
           $ref: "#/components/responses/OK_200_DocumentTypeDetails"
@@ -276,8 +345,7 @@ paths:
           $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-          
-          
+
   /v1/crossreferences:
 
     post:
@@ -290,30 +358,20 @@ paths:
         - {}
         - BearerAuthOAuth: []
       parameters:
-        #header
-          #common header parameter
-          - $ref: "#/components/parameters/X-Request-ID"
-          #mandatory header parameter
-          #optional header parameters
-          - $ref: "#/components/parameters/USR-IP-Address_optional"
-          - $ref: "#/components/parameters/Idempotency-Key"
-        #path # NO PATH PARAMETER
-        #query # NO QUERY PARAMETER
-
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/Idempotency-Key"
       requestBody:
         $ref: "#/components/requestBodies/createCrossReferences"
-
       responses:
-        '200':
-          $ref: "#/components/responses/OK_200_CreateCrossReferences"
+        '201':
+          $ref: "#/components/responses/CREATED_201_CreateCrossReferences"
         '400':
           $ref: "#/components/responses/BAD_REQUEST_400"
         '401':
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
         '405':
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
@@ -329,41 +387,106 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-    get:
-      summary: Query cross-references
-      description: |
-        Query cross-references. This method returns an array of cross-references matching the search criteria. 
-
-        Although the search criteria are optional, the key of at least one of the cross-reference relata and its respective data storage or key type must be provided. 
-        That is, either or both the ID of the document (_documentId_) and its data storage (_documentStore_) or the key (_key_) and the type (_keyType_) of the object related to the document in question must be provided. 
-      operationId: queryCrossReferences
+    put:
+      summary: Update cross-references
+      description: Updates an array of cross-references between documents and other objects.
+      operationId: updateCrossReferences
       tags:
         - Cross-Reference Service (CRS)
       security:
         - {}
         - BearerAuthOAuth: []
       parameters:
-        #header
-          #common header parameter
-          - $ref: "#/components/parameters/X-Request-ID"
-          #mandatory header parameter
-          #optional header parameters
-          - $ref: "#/components/parameters/USR-IP-Address_optional"
-          - $ref: "#/components/parameters/Idempotency-Key"
-        #path # NO PATH PARAMETER
-        #query
-          #mandatory query parameter
-          #optional query parameters
-          - $ref: "#/components/parameters/documentStoreQueryParameter"
-          - $ref: "#/components/parameters/documentId"
-          - $ref: "#/components/parameters/keyType"
-          - $ref: "#/components/parameters/key"
-          - $ref: "#/components/parameters/documentCategory"
-          - $ref: "#/components/parameters/dateFrom"
-          - $ref: "#/components/parameters/dateTo"
-          - $ref: "#/components/parameters/pageOptional"
-          - $ref: "#/components/parameters/itemsPerPageOptional"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/Idempotency-Key"
+      requestBody:
+        $ref: "#/components/requestBodies/updateCrossReferences"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_UpdateCrossReferences"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '409':
+          $ref: "#/components/responses/CONFLICT_409"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
+  /v1/crossreferences/{key-type}/{key}:
+
+    get:
+      summary: Get cross-references by key
+      description: |
+        Returns all cross-references identified by key type and key.
+      operationId: getCrossReferencesByKeyTypeAndKey
+      tags:
+        - Cross-Reference Service (CRS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/keyTypePathParameter"
+        - $ref: "#/components/parameters/keyPathParameter"
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_CrossReferencesByKey"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '405':
+          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
+        '408':
+          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
+        '415':
+          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/documents/{document-id}/crossreferences:
+
+    get:
+      summary: Get cross-references for a document
+      description: |
+        Returns cross-references for a single document. The document store may be supplied if needed; otherwise the implementation may assume the default store.
+      operationId: getCrossReferencesForDocument
+      tags:
+        - Cross-Reference Service (CRS)
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/documentIdPathParameter"
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/pageOptional"
+        - $ref: "#/components/parameters/itemsPerPageOptional"
       responses:
         '200':
           $ref: "#/components/responses/OK_200_QueryCrossReferences"
@@ -379,57 +502,6 @@ paths:
           $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
         '408':
           $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-          
-    put:
-      summary: Updates cross-references
-      description:  Updates an array of new cross-references between documents and some other objects (such as claims, credit transfers and payment requests).
-      operationId: updateCrossReferences
-      tags:
-        - Cross-Reference Service (CRS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        #header
-          #common header parameter
-          - $ref: "#/components/parameters/X-Request-ID"
-          #mandatory header parameter
-          #optional header parameters
-          - $ref: "#/components/parameters/USR-IP-Address_optional"
-          - $ref: "#/components/parameters/Idempotency-Key"
-        #path # NO PATH PARAMETER
-        #query # NO QUERY PARAMETER
-
-      requestBody:
-        $ref: "#/components/requestBodies/updateCrossReferences"
-
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_UpdateCrossReferences"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
         '415':
           $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
@@ -439,35 +511,27 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/crossreferences/{document-store}/{document-id}/{key-type}/{key}:
+  /v1/documents/{document-id}/crossreferences/{key-type}/{key}:
 
     delete:
-      summary: Delete a cross-reference
-      description: Delete a cross-reference. 
-      operationId: deleteCrossReference
+      summary: Delete a cross-reference for a document
+      description: |
+        Deletes a cross-reference identified by document, key type and key. The document store may be supplied if needed; otherwise the implementation may assume the default store.
+      operationId: deleteCrossReferenceForDocument
       tags:
         - Cross-Reference Service (CRS)
       security:
         - {}
         - BearerAuthOAuth: []
       parameters:
-        #header
-          #common header parameter
-          - $ref: "#/components/parameters/X-Request-ID"
-          #mandatory header parameters
-          #optional header parameters
-          - $ref: "#/components/parameters/USR-IP-Address_optional"
-          - $ref: "#/components/parameters/Idempotency-Key"
-        #path
-          #mandatory path parameters
-          - $ref: "#/components/parameters/documentStorePathParameter"
-          - $ref: "#/components/parameters/documentIdPathParameter"
-          - $ref: "#/components/parameters/keyTypePathParameter"
-          - $ref: "#/components/parameters/keyPathParameter"
-          #optional path parameter NO QUERY PARAMETER
-        #query
-          - $ref: "#/components/parameters/externalEventId"
-
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/Idempotency-Key"
+        - $ref: "#/components/parameters/documentIdPathParameter"
+        - $ref: "#/components/parameters/keyTypePathParameter"
+        - $ref: "#/components/parameters/keyPathParameter"
+        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/externalEventId"
       responses:
         '200':
           $ref: "#/components/responses/OK_200_DeleteCrossReferences"
@@ -493,7 +557,7 @@ paths:
           $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-          
+
 components:
 #####################################################
 # Predefined Components
@@ -547,20 +611,29 @@ components:
       required: false
       example: 192.168.8.78
 
-    documentsId:
-      name: documents-id
+    documentProcessIdPath:
+      name: document-process-id
       in: path
       description: |
-        Document id in path
+        Document process id in path.
       required: true
       schema:
         $ref: "#/components/schemas/uuid"
         
-    documentsProcessIdQuery:
-      name: documentsProcessId
+    documentProcessIdQuery:
+      name: documentProcessId
       in: query
       description: |
-        Documents process id.
+        Document process id.
+      required: false
+      schema:
+        $ref: "#/components/schemas/uuid"
+
+    documentIdQuery:
+      name: documentId
+      in: query
+      description: |
+        Document id for filtering.
       required: false
       schema:
         $ref: "#/components/schemas/uuid"
@@ -568,38 +641,35 @@ components:
     documentStore:
       name: document-store
       description: |
-        The name of the store where the documents are located. 
+        The name of the store where the document is located. 
       in: path
       required: true
       schema:
-        type: string
+        $ref: "#/components/schemas/documentStore"
 
     page:
       name: page
       in: query
-      description: Page number.
-      required: true
+      description: Page number. If not specified, the default is 1.
+      required: false
       example: 3
       schema:
-        type: integer
+        $ref: "#/components/schemas/pagingPageNumber"
 
     itemsPerPage:
       name: itemsPerPage
       in: query
-      description: Number of items per page.
-      required: true
+      description: Number of items per page. If not specified, the default is 10.
+      required: false
       example: 10
       schema:
-        type: integer
+        $ref: "#/components/schemas/pagingItemsPerPage"
 
     dateFrom:
       name: dateFrom
       in: query
       description: |
-        Conditional: Starting date (inclusive the date dateFrom) of the expected list, mandated if no delta access is required
-        and if bookingStatus does not equal "information".
-
-        The relevant date is usually the booking date of the instrument e.g. financial transaction or currency rate value date.
+        Starting date (inclusive) of the expected list.
       required: false
       example: "2024-11-29"
       schema:
@@ -610,11 +680,7 @@ components:
       name: dateTo
       in: query
       description: |
-        End date (inclusive the data dateTo) of the expected list, default is "now" if not given.
-
-        Might be ignored if a delta function is used.
-
-        The relevant date is usually the booking date of the instrument e.g. financial transaction or currency rate value date.
+        End date (inclusive) of the expected list, default is "now" if not given.
       required: false
       example: "2024-11-30"
       schema:
@@ -634,7 +700,25 @@ components:
       name: sender-kennitala
       in: path
       description: |
-        Kennitala of the documents sender.
+        Kennitala of the document sender.
+      required: true
+      schema:
+        $ref: "#/components/schemas/kennitala"
+
+    ownerKennitalaQuery:
+      name: ownerKennitala
+      in: query
+      description: |
+        Kennitala of the document owner for filtering.
+      required: false
+      schema:
+        $ref: "#/components/schemas/kennitala"
+
+    ownerKennitalaRequiredQuery:
+      name: ownerKennitala
+      in: query
+      description: |
+        Kennitala of the document owner.
       required: true
       schema:
         $ref: "#/components/schemas/kennitala"
@@ -647,7 +731,8 @@ components:
       required: false
       schema:
         type: string
-        minLength: 10
+        minLength: 1
+        maxLength: 10
 
     status:
       name: status
@@ -692,7 +777,7 @@ components:
       name: document-id
       in: path
       description: |
-        The ID of document related to the object in question. The ID is a unique identifier for the document in its source system. The format of the key is determined by source system.
+        The ID of document related to the object in question. The ID is a unique identifier for the document in its source system.
       required: true
       example: "00ec5225-8a64-48a2-b6bf-f4ef558b27df"
       schema:
@@ -733,7 +818,7 @@ components:
       name: documentId
       in: query
       description: |
-        The ID of document related to the object in question. The ID is a unique identifier for the document in its source system. The format of the key is determined by source system.
+        The ID of document related to the object in question. The ID is a unique identifier for the document in its source system.
       required: false
       example: "00ec5225-8a64-48a2-b6bf-f4ef558b27df"
       schema:
@@ -743,7 +828,8 @@ components:
       name: documentStore
       in: query
       description: |
-        Document data storage system. The value is one of the following:
+        Document data storage system. The value is one of the following.
+        If omitted, default value is `Ark`.
       required: false
       example: Ark
       schema:
@@ -796,7 +882,7 @@ components:
       required: false
       example: 3
       schema:
-        type: integer
+        $ref: "#/components/schemas/pagingPageNumber"
 
     itemsPerPageOptional:
       name: itemsPerPage
@@ -805,12 +891,22 @@ components:
       required: false
       example: 10
       schema:
-        type: integer
+        $ref: "#/components/schemas/pagingItemsPerPage"
 
   schemas:
     #####################################################
     # Predefined Schemas
     #####################################################
+
+    pagingPageNumber:
+      description: Page number.
+      type: integer
+      minimum: 1
+
+    pagingItemsPerPage:
+      description: Number of items per page.
+      type: integer
+      minimum: 1
 
     #####################################################
     # _links
@@ -875,6 +971,7 @@ components:
         code:
           description: Unique code for the document type.
           type: string
+          minLength: 1
           maxLength: 10
         name:
           description: Short description for the document type
@@ -883,7 +980,7 @@ components:
         durableMedia:
           description: |
             Control flag describing if document type is durable media. If document type
-            is durable media then any documents process using this code can not be updated.
+            is durable media then any document process using this code can not be updated.
           type: boolean
         description:
           description: |
@@ -894,48 +991,119 @@ components:
     documentTypeList:
       description: |
         List of document type with details.
-      type: object
-      required:
-        - documentTypes
-      properties:
-        documentTypes:
-          type: array
-          items:
-            $ref: "#/components/schemas/documentTypeDetails"
+      type: array
+      items:
+        $ref: "#/components/schemas/documentTypeDetails"
 
     fileDetails:
       description: |
         Document details.
+      oneOf:
+        - $ref: "#/components/schemas/fileDetailsXML"
+        - $ref: "#/components/schemas/fileDetailsPDF"
+        - $ref: "#/components/schemas/fileDetailsLINK"
+      discriminator:
+        propertyName: fileType
+        mapping:
+          XML: "#/components/schemas/fileDetailsXML"
+          PDF: "#/components/schemas/fileDetailsPDF"
+          LINK: "#/components/schemas/fileDetailsLINK"
+
+    fileDescription:
+      description: |
+        The file description usually in this format: "<Company name as sender> - <Document type>"
+      type: string
+      maxLength: 140
+
+    fileDetailsCommon:
       type: object
       required:
         - id
         - receiverKennitala
-        - fileType
       properties:
         id:
           $ref: "#/components/schemas/uuid"
         description:
-          description: |
-            The file description usually in this format: "<Company name as sender> - <Document type>"
-          type: string
-          maxLength: 140
+          $ref: "#/components/schemas/fileDescription"
         receiverKennitala:
           $ref: "#/components/schemas/kennitala"
+
+    fileTypeXML:
+      type: string
+      enum:
+        - "XML"
+
+    fileTypePDF:
+      type: string
+      enum:
+        - "PDF"
+
+    fileTypeLINK:
+      type: string
+      enum:
+        - "LINK"
+
+    filePayloadXML:
+      type: object
+      required:
+        - fileType
+        - file
+      properties:
         fileType:
-          description: |
-            File type only xml, pdf, link is allowed. Xml and pdf are physical files and link is reference to file
-          type: string
-          enum:
-            - "XML"
-            - "PDF"
+          $ref: "#/components/schemas/fileTypeXML"
         file:
-          description: The file in the form of base64 encoded characters
+          description: XML document payload as a plain string.
+          type: string
+
+    filePayloadPDF:
+      type: object
+      required:
+        - fileType
+        - file
+      properties:
+        fileType:
+          $ref: "#/components/schemas/fileTypePDF"
+        file:
+          description: The PDF file in the form of base64 encoded characters.
           type: string
           format: byte
 
-    documentsProcessDetails:
+    filePayloadLINK:
+      type: object
+      required:
+        - fileType
+        - file
+      properties:
+        fileType:
+          $ref: "#/components/schemas/fileTypeLINK"
+        file:
+          description: Link or external reference to the file as a plain string.
+          type: string
+
+    fileDetailsXML:
       description: |
-        Documents process details.
+        XML file details where the payload is XML content as plain text.
+      allOf:
+        - $ref: "#/components/schemas/fileDetailsCommon"
+        - $ref: "#/components/schemas/filePayloadXML"
+
+    fileDetailsPDF:
+      description: |
+        PDF file details where the payload is base64-encoded bytes.
+      allOf:
+        - $ref: "#/components/schemas/fileDetailsCommon"
+        - $ref: "#/components/schemas/filePayloadPDF"
+
+    fileDetailsLINK:
+      description: |
+        LINK file details where the payload is a string reference to the file.
+      allOf:
+        - $ref: "#/components/schemas/fileDetailsCommon"
+        - $ref: "#/components/schemas/filePayloadLINK"
+
+    documentProcessDetails:
+      description: |
+        Document process details.
       type: object
       required:
         - id
@@ -947,7 +1115,7 @@ components:
         id:
           $ref: "#/components/schemas/uuid"
         name:
-          description: Short description for the documents process
+          description: Short description for the document process
           type: string
           maxLength: 70
         description:
@@ -961,6 +1129,8 @@ components:
           description: |
             Document type code retrieved from {sender-kennitala}/types
           type: string
+          minLength: 1
+          maxLength: 10
         files:
           type: array
           items:
@@ -985,47 +1155,85 @@ components:
     fileWithStatusDetails:
       description: |
         Document details.
+      oneOf:
+        - $ref: "#/components/schemas/fileWithStatusDetailsXML"
+        - $ref: "#/components/schemas/fileWithStatusDetailsPDF"
+        - $ref: "#/components/schemas/fileWithStatusDetailsLINK"
+      discriminator:
+        propertyName: fileType
+        mapping:
+          XML: "#/components/schemas/fileWithStatusDetailsXML"
+          PDF: "#/components/schemas/fileWithStatusDetailsPDF"
+          LINK: "#/components/schemas/fileWithStatusDetailsLINK"
+
+    fileWithStatusCommon:
+      allOf:
+        - $ref: "#/components/schemas/fileDetailsCommon"
+        - type: object
+          required:
+            - status
+            - isCrossReferenced
+          properties:
+            status:
+              $ref: "#/components/schemas/processStatus"
+            statusMessage:
+              description: Process status message
+              type: string
+              maxLength: 250
+            isCrossReferenced:
+              description: |
+                Indicates whether the document is cross-referenced to another object.
+              type: boolean
+
+    fileTypeTagXML:
       type: object
       required:
-        - id
-        - receiverKennitala
-        - status
+        - fileType
       properties:
-        id:
-          $ref: "#/components/schemas/uuid"
-        description:
-          description: |
-            The file description usually in this format: "<Company name as sender> - <Document type>"
-          type: string
-          maxLength: 140
-        receiverKennitala:
-          description: |
-            The ID Number of the receiver of the document. https://en.wikipedia.org/wiki/Icelandic_identification_number
-          type: string
-          maxLength: 10
         fileType:
-          description: |
-            File type only xml, pdf, link is allowed. Xml and pdf are physical files and link is reference to file
-          type: string
-          enum:
-            - "XML"
-            - "PDF"
-        status:
-          $ref: "#/components/schemas/processStatus"
-        statusMessage:
-          description: Process status message
-          type: string
-          maxLength: 250
+          $ref: "#/components/schemas/fileTypeXML"
 
-    documentsProcessWithStatusDetails:
+    fileTypeTagPDF:
+      type: object
+      required:
+        - fileType
+      properties:
+        fileType:
+          $ref: "#/components/schemas/fileTypePDF"
+
+    fileTypeTagLINK:
+      type: object
+      required:
+        - fileType
+      properties:
+        fileType:
+          $ref: "#/components/schemas/fileTypeLINK"
+
+    fileWithStatusDetailsXML:
+      allOf:
+        - $ref: "#/components/schemas/fileWithStatusCommon"
+        - $ref: "#/components/schemas/fileTypeTagXML"
+
+    fileWithStatusDetailsPDF:
+      allOf:
+        - $ref: "#/components/schemas/fileWithStatusCommon"
+        - $ref: "#/components/schemas/fileTypeTagPDF"
+
+    fileWithStatusDetailsLINK:
+      allOf:
+        - $ref: "#/components/schemas/fileWithStatusCommon"
+        - $ref: "#/components/schemas/fileTypeTagLINK"
+
+    documentProcessWithStatusDetails:
       description: |
-        Documents process details.
+        Document process details.
       type: object
       required:
         - id
         - name
         - senderKennitala
         - documentTypeCode
+        - status
         - files
       properties:
         id:
@@ -1046,6 +1254,8 @@ components:
           description: |
             Document type code retrieved from {sender-kennitala}/types
           type: string
+          minLength: 1
+          maxLength: 10
         status:
           $ref: "#/components/schemas/processStatus"
         files:
@@ -1053,29 +1263,63 @@ components:
           items:
             $ref: "#/components/schemas/fileWithStatusDetails"
 
-    documentsProcessWithStatusList:
+    documentProcessWithStatusSummary:
       description: |
-        List of documents with details.
+        Document process summary details for list responses.
       type: object
       required:
-        - documentsProcesses
+        - id
+        - name
+        - senderKennitala
+        - documentTypeCode
+        - status
       properties:
-        documentsProcesses:
-          type: array
-          items:
-            $ref: "#/components/schemas/documentsProcessWithStatusDetails"
+        id:
+          $ref: "#/components/schemas/uuid"
+        name:
+          description: Short description for the process
+          type: string
+          maxLength: 70
+        description:
+          description: |
+            The file description usually in this format: "<Company name as sender> - <Document type>"
+          type: string
+          maxLength: 140
+        senderKennitala:
+          $ref: "#/components/schemas/kennitala"
+        documentTypeCode:
+          description: |
+            Document type code retrieved from {sender-kennitala}/types
+          type: string
+          minLength: 1
+          maxLength: 10
+        status:
+          $ref: "#/components/schemas/processStatus"
+
+    documentProcessWithStatusList:
+      description: |
+        List of document processes with summary details.
+      type: array
+      items:
+        $ref: "#/components/schemas/documentProcessWithStatusSummary"
+
+    documentWithStatusList:
+      description: |
+        List of document items with details.
+      type: array
+      items:
+        $ref: "#/components/schemas/fileWithStatusDetails"
 
     uuid:
       description: Unique Identifier 
       type: string
-      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
-      minLength: 36
-      maxLength: 36
+      format: uuid
 
     crossReferencesList:
       description: |
         List of cross-references.
       type: array
+      minItems: 1
       items:
         $ref: "#/components/schemas/crossReference"
 
@@ -1124,7 +1368,7 @@ components:
 
     documentId:
       description: |
-        The ID of document related to the object in question. The ID is a unique identifier for the document in its source system. The format of the key is determined by source system.
+        The ID of document related to the object in question. The ID is a unique identifier for the document in its source system.
       type: string
       example: "00ec5225-8a64-48a2-b6bf-f4ef558b27df"
 
@@ -1894,7 +2138,7 @@ components:
 
     Error405_IOBWS:
       description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 401.
+        IOBWS specific definition of reporting error information in case of a HTTP error code 405.
       type: object
       properties:
         messages:
@@ -1929,9 +2173,13 @@ components:
           $ref: "#/components/schemas/_linksAll"
       example:
         {
-          "category": "ERROR",
-          "code": "STATUS_INVALID",
-          "text": "additional text information of the Bank up to 500 characters"
+          "messages": [
+            {
+              "category": "ERROR",
+              "code": "STATUS_INVALID",
+              "text": "additional text information of the Bank up to 500 characters"
+            }
+          ]
         }
 
     Error429_IOBWS:
@@ -1947,9 +2195,13 @@ components:
           $ref: "#/components/schemas/_linksAll"
       example:
         {
-          "category": "ERROR",
-          "code": "ACCESS_EXCEEDED",
-          "text": "additional text information of the Bank up to 500 characters"
+          "messages": [
+            {
+              "category": "ERROR",
+              "code": "ACCESS_EXCEEDED",
+              "text": "additional text information of the Bank up to 500 characters"
+            }
+          ]
         }
 
   requestBodies:
@@ -1959,12 +2211,12 @@ components:
 
     documentsProcessInitiation:
       description: |
-        JSON request body for a documents process initiation or update request message
+        JSON request body for a document process initiation or update request message
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentsProcessDetails"
+            $ref: "#/components/schemas/documentProcessDetails"
           examples: 
             example:
               $ref: "#/components/examples/documentsProcessInitiation_json_Example"
@@ -2011,8 +2263,34 @@ components:
         Location of the created resource.
       schema:
         type: string
-        format: url
+        format: uri
       required: false
+
+    X-Paging-CurrentPage:
+      description: |
+        Current page number
+      schema:
+        $ref: "#/components/schemas/pagingPageNumber"
+
+    X-Paging-TotalPages:
+      description: |
+        Total pages
+      schema:
+        type: integer
+        minimum: 0
+
+    X-Paging-TotalItems:
+      description: |
+        Total items
+      schema:
+        type: integer
+        minimum: 0
+
+    X-Paging-PerPage:
+      description: |
+        Items per page
+      schema:
+        $ref: "#/components/schemas/pagingItemsPerPage"
 
   responses:
     #####################################################
@@ -2024,30 +2302,83 @@ components:
     #####################################################
 
     OK_200_DocumentsProcessListWithStatusDetails:
-      description: Get documents process details
+      description: Get document process details
       headers:
+        X-Paging-CurrentPage:
+          $ref: "#/components/headers/X-Paging-CurrentPage"
+        X-Paging-TotalPages:
+          $ref: "#/components/headers/X-Paging-TotalPages"
+        X-Paging-TotalItems:
+          $ref: "#/components/headers/X-Paging-TotalItems"
+        X-Paging-PerPage:
+          $ref: "#/components/headers/X-Paging-PerPage"
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentsProcessWithStatusList"
+            $ref: "#/components/schemas/documentProcessWithStatusList"
           examples: 
             example:
-              $ref: "#/components/examples/documentsProcessWithStatusList-200_json_Example"
+              $ref: "#/components/examples/documentProcessWithStatusList-200_json_Example"
 
     OK_200_DocumentsProcessWithStatusDetails:
-      description: Get documents process details
+      description: Get document process details
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentProcessWithStatusDetails"
+          examples: 
+            example:
+              $ref: "#/components/examples/documentProcessWithStatusDetails-200_json_Example"
+
+    CREATED_201_DocumentsProcessWithStatusDetails:
+      description: Document process created
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentProcessWithStatusDetails"
+          examples:
+            example:
+              $ref: "#/components/examples/documentProcessWithStatusDetails-200_json_Example"
+
+    OK_200_DocumentWithStatusDetails:
+      description: Get document details
       headers:
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentsProcessWithStatusDetails"
-          examples: 
-            example:
-              $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
+            $ref: "#/components/schemas/fileWithStatusDetails"
+
+    OK_200_DocumentListWithStatusDetails:
+      description: Get document list details
+      headers:
+        X-Paging-CurrentPage:
+          $ref: "#/components/headers/X-Paging-CurrentPage"
+        X-Paging-TotalPages:
+          $ref: "#/components/headers/X-Paging-TotalPages"
+        X-Paging-TotalItems:
+          $ref: "#/components/headers/X-Paging-TotalItems"
+        X-Paging-PerPage:
+          $ref: "#/components/headers/X-Paging-PerPage"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentWithStatusList"
 
     OK_200_UpdateDocumentsProcess:
       description: OK
@@ -2057,10 +2388,10 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentsProcessWithStatusDetails"
+            $ref: "#/components/schemas/documentProcessWithStatusDetails"
           examples: 
             example:
-              $ref: "#/components/examples/documentsProcessWithStatusDetails-200_json_Example"
+              $ref: "#/components/examples/documentProcessWithStatusDetails-200_json_Example"
 
     OK_200_DocumentTypeDetails:
       description: OK
@@ -2079,6 +2410,17 @@ components:
       description: |
         Cross-references created successfully.
       headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+
+    CREATED_201_CreateCrossReferences:
+      description: |
+        Cross-references created successfully.
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
 
@@ -2087,25 +2429,27 @@ components:
         List of cross-references matching query parameters.
       headers:
         X-Paging-CurrentPage:
-          description: |
-            Current page number
-          schema:
-            type: integer
+          $ref: "#/components/headers/X-Paging-CurrentPage"
         X-Paging-TotalPages:
-          description: |
-            Total pages
-          schema:
-            type: integer
+          $ref: "#/components/headers/X-Paging-TotalPages"
         X-Paging-TotalItems:
-          description: |
-            Total items
-          schema:
-            type: integer
+          $ref: "#/components/headers/X-Paging-TotalItems"
         X-Paging-PerPage:
-          description: |
-            Items per page
+          $ref: "#/components/headers/X-Paging-PerPage"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
           schema:
-            type: integer
+            $ref: "#/components/schemas/crossReferencesList"
+          examples:
+            "Example":
+              $ref: "#/components/examples/getCrossReferences-200_json_Example"
+
+    OK_200_CrossReferencesByKey:
+      description: |
+        Cross-references matching key type and key.
+      headers:
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
       content:
@@ -2322,22 +2666,20 @@ components:
     documentTypeListResponse-200_json_Example:
       description: List of document types.
       value:
-        {
-          "documentTypes": [
-            { 
-              "code": "STVO",
-              "name": "/typ/3254b7b2-302c-72",
-              "durableMedia": true,
-              "description": "Pay slip from Company"
-            },
-            { 
-              "code": "IDFR",
-              "name": "/typ/3254b7b2-302c-72",
-              "durableMedia": true,
-              "description": "Account statement from Company"
-            }
-          ]
-        }
+        [
+          { 
+            "code": "STVO",
+            "name": "/typ/3254b7b2-302c-72",
+            "durableMedia": true,
+            "description": "Pay slip from Company"
+          },
+          { 
+            "code": "IDFR",
+            "name": "/typ/3254b7b2-302c-72",
+            "durableMedia": true,
+            "description": "Account statement from Company"
+          }
+        ]
 
     documentsProcessInitiation_json_Example:
       description: Documents upload request.
@@ -2357,17 +2699,17 @@ components:
               "file": "The file in the form of base64 encoded characters"
             },
             {
-              "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
+              "id": "3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f",
               "description": "Company - Account statement",
               "receiverKennitala": "1111112249",
-              "fileType": "PDF",
-              "file": "The file in the form of base64 encoded characters"
+              "fileType": "LINK",
+              "file": "https://documents.example.com/file/3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f"
             } 
           ]
         }
 
-    documentsProcessWithStatusDetails-200_json_Example:
-      description: Documents process result.
+    documentProcessWithStatusDetails-200_json_Example:
+      description: Document process result.
       value: 
         {
           "id": "3a378271-0a43-aa66-f273-377ae9ce135c",
@@ -2383,52 +2725,34 @@ components:
               "receiverKennitala": "1111112239",
               "fileType": "PDF",
               "status": "received",
-              "statusMessage": "File is currently being processed"
+              "statusMessage": "File is currently being processed",
+              "isCrossReferenced": true
             },
             {
-              "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
+              "id": "3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f",
               "description": "",
               "receiverKennitala": "1111112249",
-              "fileType": "PDF",
+              "fileType": "LINK",
               "status": "received",
-              "statusMessage": "File is currently being processed"
+              "statusMessage": "File is currently being processed",
+              "isCrossReferenced": false
             }
           ]
         }
 
-    documentsProcessWithStatusList-200_json_Example:
+    documentProcessWithStatusList-200_json_Example:
       description: Documents query result.
       value: 
-        {
-          "documentsProcesses": [
-            {
-              "id": "3a378271-0a43-aa66-f273-377ae9ce135c",
-              "name": "Account statements",
-              "description": "Account statements for june 2022",
-              "senderKennitala": "1111111199",
-              "documentTypeCode": "IDFR",
-              "status": "received",
-              "files": [
-                {
-                  "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
-                  "description": "",
-                  "receiverKennitala": "1111112239",
-                  "fileType": "PDF",
-                  "status": "received",
-                  "statusMessage": "File is currently being processed"
-                },
-                {
-                  "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
-                  "description": "",
-                  "receiverKennitala": "1111112249",
-                  "fileType": "PDF",
-                  "status": "received",
-                  "statusMessage": "File is currently being processed"
-                }
-              ]
-            }
-          ]
-        }
+        [
+          {
+            "id": "3a378271-0a43-aa66-f273-377ae9ce135c",
+            "name": "Account statements",
+            "description": "Account statements for june 2022",
+            "senderKennitala": "1111111199",
+            "documentTypeCode": "IDFR",
+            "status": "received"
+          }
+        ]
 
     createCrossReferences_json_Example:
       description: Cross-references creation request.
@@ -2436,22 +2760,22 @@ components:
         [
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": Claim,
+              "keyType": "Claim",
               "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
-              "documentStore": Ark,
-              "documentCategory": Bill,
+              "documentStore": "Ark",
+              "documentCategory": "Bill",
               "documentDescription": "Bill for services rendered.",
-              "documentEffectiveDate": "2024-04-01T00:00:00",
+              "documentEffectiveDate": "2024-04-01",
               "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
           },
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": Claim,
+              "keyType": "Claim",
               "documentId": "42fbcce1-35a9-4ec3-8b40-c9a73fc3b8fe",
-              "documentStore": RBS,
-              "documentCategory": CollectionLetter,
+              "documentStore": "RBS",
+              "documentCategory": "CollectionLetter",
               "documentDescription": "Collection letter.",
-              "documentEffectiveDate": "2024-05-01T00:00:00",
+              "documentEffectiveDate": "2024-05-01",
               "externalEventId": "e7c58d4e-8cd8-462f-b440-3124f4b6e0bd"
           }
         ]
@@ -2462,25 +2786,39 @@ components:
         [
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": Claim,
+              "keyType": "Claim",
               "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
-              "documentStore": Ark,
-              "documentCategory": Bill,
+              "documentStore": "Ark",
+              "documentCategory": "Bill",
               "documentDescription": "Bill for services rendered.",
-              "documentEffectiveDate": "2024-04-01T00:00:00",
+              "documentEffectiveDate": "2024-04-01",
               "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
           },
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": Claim,
+              "keyType": "Claim",
               "documentId": "42fbcce1-35a9-4ec3-8b40-c9a73fc3b8fe",
-              "documentStore": RBS,
-              "documentCategory": CollectionLetter,
+              "documentStore": "RBS",
+              "documentCategory": "CollectionLetter",
               "documentDescription": "Collection letter.",
-              "documentEffectiveDate": "2024-05-01T00:00:00",
+              "documentEffectiveDate": "2024-05-01",
               "externalEventId": "e7c58d4e-8cd8-462f-b440-3124f4b6e0bd"
           }
         ]
+
+    getCrossReference-200_json_Example:
+      description: Single cross-reference query result.
+      value: 
+        {
+          "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
+          "keyType": "Claim",
+          "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
+          "documentStore": "Ark",
+          "documentCategory": "Bill",
+          "documentDescription": "Bill for services rendered.",
+          "documentEffectiveDate": "2024-04-01",
+          "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
+        }
 
     updateCrossReferences_json_Example:
       description: Cross-references update request.
@@ -2488,22 +2826,22 @@ components:
         [
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": Claim,
+              "keyType": "Claim",
               "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
-              "documentStore": Ark,
-              "documentCategory": Bill,
+              "documentStore": "Ark",
+              "documentCategory": "Bill",
               "documentDescription": "Bill for services rendered.",
-              "documentEffectiveDate": "2024-04-01T00:00:00",
+              "documentEffectiveDate": "2024-04-01",
               "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
           },
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": Claim,
+              "keyType": "Claim",
               "documentId": "42fbcce1-35a9-4ec3-8b40-c9a73fc3b8fe",
-              "documentStore": RBS,
-              "documentCategory": CollectionLetter,
+              "documentStore": "RBS",
+              "documentCategory": "CollectionLetter",
               "documentDescription": "Collection letter.",
-              "documentEffectiveDate": "2024-05-01T00:00:00",
+              "documentEffectiveDate": "2024-05-01",
               "externalEventId": "e7c58d4e-8cd8-462f-b440-3124f4b6e0bd"
           }
         ]

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -1207,8 +1207,6 @@ components:
             Free text reference set by the sender.
           type: string
           maxLength: 200
-        description:
-          $ref: "#/components/schemas/fileDescription"
 
     fileTypeXML:
       type: string
@@ -1361,6 +1359,8 @@ components:
               description: |
                 Indicates whether the document is cross-referenced to another object.
               type: boolean
+            description:
+              $ref: "#/components/schemas/fileDescription"
             fileType:
               description: |
                 The file type of the document.

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -693,7 +693,8 @@ components:
         Storage system. If omitted, defaults to "Ark".
       required: false
       schema:
-        $ref: "#/components/schemas/storageCode"
+        allOf:
+          - $ref: "#/components/schemas/storageCode"
         default: "Ark"
 
     USR-IP-Address_optional:
@@ -1046,7 +1047,8 @@ components:
         categoryCode:
           description: |
             Document category code.
-          $ref: "#/components/schemas/documentCategory"
+          allOf:
+            - $ref: "#/components/schemas/documentCategory"
         categoryDescription:
           description: |
             Human-readable description of the document category.
@@ -1143,7 +1145,8 @@ components:
             senderId:
               description: |
                 Identifier (kennitala) of the document sender.
-              $ref: "#/components/schemas/kennitala"
+              allOf:
+                - $ref: "#/components/schemas/kennitala"
             documentTypeCode:
               description: |
                 Document type code as returned by GET /v1/senders/{sender-id}/document-types
@@ -1256,7 +1259,8 @@ components:
         senderId:
           description: |
             Identifier (kennitala) of the document sender. Applies to all documents in the batch.
-          $ref: "#/components/schemas/kennitala"
+          allOf:
+            - $ref: "#/components/schemas/kennitala"
         documents:
           type: array
           minItems: 1
@@ -1307,16 +1311,6 @@ components:
     documentWithStatusDetails:
       description: |
         Document details.
-      oneOf:
-        - $ref: "#/components/schemas/documentWithStatusDetailsXML"
-        - $ref: "#/components/schemas/documentWithStatusDetailsPDF"
-      discriminator:
-        propertyName: fileType
-        mapping:
-          XML: "#/components/schemas/documentWithStatusDetailsXML"
-          PDF: "#/components/schemas/documentWithStatusDetailsPDF"
-
-    documentWithStatusCommon:
       allOf:
         - $ref: "#/components/schemas/documentDetailsCommon"
         - type: object
@@ -1327,16 +1321,19 @@ components:
             - status
             - isCrossReferenced
             - effectiveDate
+            - fileType
           properties:
             id:
               description: |
                 Unique document identifier. For Ark storage this is a composite key in the format
                 `{ownerId}:{senderId}:{externalId}:{YYYYMMDD}`. For RBS storage this is a UUID.
-              $ref: "#/components/schemas/documentId"
+              allOf:
+                - $ref: "#/components/schemas/documentId"
             senderId:
               description: |
                 Identifier (kennitala) of the document sender.
-              $ref: "#/components/schemas/kennitala"
+              allOf:
+                - $ref: "#/components/schemas/kennitala"
             senderName:
               description: |
                 Name of the document sender.
@@ -1352,32 +1349,13 @@ components:
               description: |
                 Indicates whether the document is cross-referenced to another object.
               type: boolean
-
-    fileTypeTagXML:
-      type: object
-      required:
-        - fileType
-      properties:
-        fileType:
-          $ref: "#/components/schemas/fileTypeXML"
-
-    fileTypeTagPDF:
-      type: object
-      required:
-        - fileType
-      properties:
-        fileType:
-          $ref: "#/components/schemas/fileTypePDF"
-
-    documentWithStatusDetailsXML:
-      allOf:
-        - $ref: "#/components/schemas/documentWithStatusCommon"
-        - $ref: "#/components/schemas/fileTypeTagXML"
-
-    documentWithStatusDetailsPDF:
-      allOf:
-        - $ref: "#/components/schemas/documentWithStatusCommon"
-        - $ref: "#/components/schemas/fileTypeTagPDF"
+            fileType:
+              description: |
+                The file type of the document.
+              type: string
+              enum:
+                - "XML"
+                - "PDF"
 
     batchWithStatusDetails:
       description: |
@@ -1719,13 +1697,6 @@ components:
     # Standard messages
     #####################################################
 
-
-    MessageCode400:
-      description: Message codes for HTTP error code 400 (BAD_REQUEST).
-      type: string
-      enum:
-        - "FORMAT_ERROR"
-        - "VALIDATION_ERROR"
 
     MessageCode401:
       description: Message codes for HTTP error code 401 (UNAUTHORIZED).

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -123,41 +123,6 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-  /v1/owners/{owner-id}/document-types:
-
-    get:
-      summary: Get document types by owner
-      description: |
-        Returns the document types available for a specific document owner, regardless of sender.
-      operationId: getDocumentTypesForOwner
-      tags:
-        - Document Types
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        - $ref: "#/components/parameters/ownerId"
-        - $ref: "#/components/parameters/Storage-System"
-        - $ref: "#/components/parameters/X-Request-ID"
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentTypeDetails"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
   #####################################################
   # Documents
   #####################################################
@@ -836,15 +801,6 @@ components:
       schema:
         $ref: "#/components/schemas/kennitala"
 
-    ownerId:
-      name: owner-id
-      in: path
-      description: |
-        Identifier (kennitala) of the document owner.
-      required: true
-      schema:
-        $ref: "#/components/schemas/kennitala"
-
     ownerIdQuery:
       name: ownerId
       in: query
@@ -1194,19 +1150,19 @@ components:
               type: string
               minLength: 1
               maxLength: 10
-        - $ref: "#/components/schemas/fileDetails"
+        - $ref: "#/components/schemas/documentDetails"
 
-    fileDetails:
+    documentDetails:
       description: |
         Document details.
       oneOf:
-        - $ref: "#/components/schemas/fileDetailsXML"
-        - $ref: "#/components/schemas/fileDetailsPDF"
+        - $ref: "#/components/schemas/documentDetailsXML"
+        - $ref: "#/components/schemas/documentDetailsPDF"
       discriminator:
         propertyName: fileType
         mapping:
-          XML: "#/components/schemas/fileDetailsXML"
-          PDF: "#/components/schemas/fileDetailsPDF"
+          XML: "#/components/schemas/documentDetailsXML"
+          PDF: "#/components/schemas/documentDetailsPDF"
 
     fileDescription:
       description: |
@@ -1214,7 +1170,7 @@ components:
       type: string
       maxLength: 140
 
-    fileDetailsCommon:
+    documentDetailsCommon:
       type: object
       required:
         - externalId
@@ -1275,18 +1231,18 @@ components:
           format: byte
           maxLength: 4194304
 
-    fileDetailsXML:
+    documentDetailsXML:
       description: |
         XML file details where the payload is XML content as plain text.
       allOf:
-        - $ref: "#/components/schemas/fileDetailsCommon"
+        - $ref: "#/components/schemas/documentDetailsCommon"
         - $ref: "#/components/schemas/filePayloadXML"
 
-    fileDetailsPDF:
+    documentDetailsPDF:
       description: |
         PDF file details where the payload is base64-encoded bytes.
       allOf:
-        - $ref: "#/components/schemas/fileDetailsCommon"
+        - $ref: "#/components/schemas/documentDetailsCommon"
         - $ref: "#/components/schemas/filePayloadPDF"
 
     batchDetails:
@@ -1321,7 +1277,7 @@ components:
               type: string
               minLength: 1
               maxLength: 10
-        - $ref: "#/components/schemas/fileDetails"
+        - $ref: "#/components/schemas/documentDetails"
 
     batchCreated:
       description: |
@@ -1348,21 +1304,21 @@ components:
         - "Completed"
         - "CompletedWithErrors"
 
-    fileWithStatusDetails:
+    documentWithStatusDetails:
       description: |
         Document details.
       oneOf:
-        - $ref: "#/components/schemas/fileWithStatusDetailsXML"
-        - $ref: "#/components/schemas/fileWithStatusDetailsPDF"
+        - $ref: "#/components/schemas/documentWithStatusDetailsXML"
+        - $ref: "#/components/schemas/documentWithStatusDetailsPDF"
       discriminator:
         propertyName: fileType
         mapping:
-          XML: "#/components/schemas/fileWithStatusDetailsXML"
-          PDF: "#/components/schemas/fileWithStatusDetailsPDF"
+          XML: "#/components/schemas/documentWithStatusDetailsXML"
+          PDF: "#/components/schemas/documentWithStatusDetailsPDF"
 
-    fileWithStatusCommon:
+    documentWithStatusCommon:
       allOf:
-        - $ref: "#/components/schemas/fileDetailsCommon"
+        - $ref: "#/components/schemas/documentDetailsCommon"
         - type: object
           required:
             - id
@@ -1413,41 +1369,15 @@ components:
         fileType:
           $ref: "#/components/schemas/fileTypePDF"
 
-    fileWithStatusDetailsXML:
+    documentWithStatusDetailsXML:
       allOf:
-        - $ref: "#/components/schemas/fileWithStatusCommon"
+        - $ref: "#/components/schemas/documentWithStatusCommon"
         - $ref: "#/components/schemas/fileTypeTagXML"
 
-    fileWithStatusDetailsPDF:
+    documentWithStatusDetailsPDF:
       allOf:
-        - $ref: "#/components/schemas/fileWithStatusCommon"
+        - $ref: "#/components/schemas/documentWithStatusCommon"
         - $ref: "#/components/schemas/fileTypeTagPDF"
-
-    documentDetail:
-      description: |
-        Full document details including file content. Returned by the single document retrieval endpoint.
-      oneOf:
-        - $ref: "#/components/schemas/documentDetailXML"
-        - $ref: "#/components/schemas/documentDetailPDF"
-      discriminator:
-        propertyName: fileType
-        mapping:
-          XML: "#/components/schemas/documentDetailXML"
-          PDF: "#/components/schemas/documentDetailPDF"
-
-    documentDetailXML:
-      description: |
-        Full document details with XML file content.
-      allOf:
-        - $ref: "#/components/schemas/fileWithStatusCommon"
-        - $ref: "#/components/schemas/filePayloadXML"
-
-    documentDetailPDF:
-      description: |
-        Full document details with PDF file content.
-      allOf:
-        - $ref: "#/components/schemas/fileWithStatusCommon"
-        - $ref: "#/components/schemas/filePayloadPDF"
 
     batchWithStatusDetails:
       description: |
@@ -1537,7 +1467,7 @@ components:
         List of document items with details.
       type: array
       items:
-        $ref: "#/components/schemas/fileWithStatusDetails"
+        $ref: "#/components/schemas/documentWithStatusDetails"
 
     documentCreated:
       description: |
@@ -2392,7 +2322,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentDetail"
+            $ref: "#/components/schemas/documentWithStatusDetails"
 
     OK_200_DocumentListWithStatusDetails:
       description: Get document list details

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -30,6 +30,12 @@ info:
     
     Space
 
+    ## Caveat on batch operations
+
+    The batch endpoints (`/v1/batches`) are included in this specification as a design target.
+    The underlying implementation is not yet available and the batch contract will be subject
+    to review in Q3 2026.
+
   license:
     name: Creative Commons Attribution 4.0 International Public License
     url: https://creativecommons.org/licenses/by/4.0/
@@ -166,6 +172,10 @@ paths:
       summary: Search documents
       description: |
         Returns a filtered list of documents. Use `GET /v1/documents/{document-id}` for retrieval of a single document by identifier.
+
+        **Implementation note:** The underlying SOAP operation (`GetDocuments`) does not currently
+        support filtering by `senderId` alone — `ownerId` is always required. Filtering solely
+        by sender is under analysis and may be exposed through a new endpoint in a future revision.
       operationId: searchDocuments
       tags:
         - Documents

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -727,7 +727,7 @@ components:
         Batch id in path.
       required: true
       schema:
-        $ref: "#/components/schemas/uuid"
+        type: string
         
     batchIdQuery:
       name: batchId
@@ -736,7 +736,7 @@ components:
         Batch id.
       required: false
       schema:
-        $ref: "#/components/schemas/uuid"
+        type: string
 
     documentIdQuery:
       name: documentId

--- a/Deliverables/IOBWS-Documents3.1.yaml
+++ b/Deliverables/IOBWS-Documents3.1.yaml
@@ -53,260 +53,10 @@ servers:
 paths:
 
   #####################################################
-  # Document Service
+  # Document Types
   #####################################################
 
-  /v1/document-processes:
-
-    post:
-      summary: Create a document process
-      description: |
-        Creates a new document process and uploads one or more documents.
-      operationId: createDocumentProcess
-      tags:
-        - Document Service (DS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        - $ref: "#/components/parameters/X-Request-ID"
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-        - $ref: "#/components/parameters/Idempotency-Key"
-      requestBody:
-        $ref: "#/components/requestBodies/documentsProcessInitiation"
-      responses:
-        '201':
-          $ref: "#/components/responses/CREATED_201_DocumentsProcessWithStatusDetails"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
-    get:
-      summary: Search document processes
-      description: |
-        Returns a filtered list of document processes.
-      operationId: searchDocumentProcesses
-      tags:
-        - Document Service (DS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        - $ref: "#/components/parameters/senderKennitalaQuery"
-        - $ref: "#/components/parameters/documentTypeCode"
-        - $ref: "#/components/parameters/status"
-        - $ref: "#/components/parameters/dateFrom"
-        - $ref: "#/components/parameters/dateTo"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/itemsPerPage"
-        - $ref: "#/components/parameters/X-Request-ID"
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentsProcessListWithStatusDetails"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
-  /v1/document-processes/{document-process-id}:
-
-    get:
-      summary: Get a single document process
-      description: |
-        Returns a single document process by process identifier.
-      operationId: getDocumentProcessById
-      tags:
-        - Document Service (DS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        - $ref: "#/components/parameters/documentProcessIdPath"
-        - $ref: "#/components/parameters/X-Request-ID"
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentsProcessWithStatusDetails"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
-    put:
-      summary: Replace a document process
-      description: |
-        Replaces the document process resource. The request body represents the full desired state of the process.
-      operationId: replaceDocumentProcess
-      tags:
-        - Document Service (DS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        - $ref: "#/components/parameters/documentProcessIdPath"
-        - $ref: "#/components/parameters/X-Request-ID"
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-      requestBody:
-        $ref: "#/components/requestBodies/documentsProcessInitiation"
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_UpdateDocumentsProcess"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
-  /v1/documents/{document-id}:
-
-    get:
-      summary: Get a single document
-      description: |
-        Returns a single document by identifier. If not specified, the implementation may assume the default document store (e.g. Ark).
-      operationId: getDocumentById
-      tags:
-        - Document Service (DS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        - $ref: "#/components/parameters/documentIdPathParameter"
-        - $ref: "#/components/parameters/documentStoreQueryParameter"
-        - $ref: "#/components/parameters/ownerKennitalaRequiredQuery"
-        - $ref: "#/components/parameters/X-Request-ID"
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentWithStatusDetails"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '404':
-          $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
-  /v1/documents:
-
-    get:
-      summary: Search documents
-      description: |
-        Returns a filtered list of documents. Use `GET /v1/documents/{document-id}` for retrieval of a single document by identifier.
-      operationId: searchDocuments
-      tags:
-        - Document Service (DS)
-      security:
-        - {}
-        - BearerAuthOAuth: []
-      parameters:
-        - $ref: "#/components/parameters/documentStoreQueryParameter"
-        - $ref: "#/components/parameters/senderKennitalaQuery"
-        - $ref: "#/components/parameters/ownerKennitalaQuery"
-        - $ref: "#/components/parameters/documentTypeCode"
-        - $ref: "#/components/parameters/status"
-        - $ref: "#/components/parameters/dateFrom"
-        - $ref: "#/components/parameters/dateTo"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/itemsPerPage"
-        - $ref: "#/components/parameters/X-Request-ID"
-        - $ref: "#/components/parameters/USR-IP-Address_optional"
-      responses:
-        '200':
-          $ref: "#/components/responses/OK_200_DocumentListWithStatusDetails"
-        '400':
-          $ref: "#/components/responses/BAD_REQUEST_400"
-        '401':
-          $ref: "#/components/responses/UNAUTHORIZED_401"
-        '403':
-          $ref: "#/components/responses/FORBIDDEN_403"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
-        '429':
-          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
-        '500':
-          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
-        '503':
-          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
-
-  /v1/document-senders/{sender-kennitala}/document-types:
+  /v1/senders/{sender-id}/document-types:
 
     get:
       summary: Get list of all document types
@@ -314,12 +64,12 @@ paths:
         Returns the document types available for a specific sender.
       operationId: getDocumentTypesForSender
       tags:
-        - Document Service (DS)
+        - Document Types
       security:
         - {}
         - BearerAuthOAuth: []
       parameters:
-        - $ref: "#/components/parameters/senderKennitala"
+        - $ref: "#/components/parameters/senderId"
         - $ref: "#/components/parameters/X-Request-ID"
         - $ref: "#/components/parameters/USR-IP-Address_optional"
       responses:
@@ -333,18 +83,346 @@ paths:
           $ref: "#/components/responses/FORBIDDEN_403"
         '404':
           $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
           $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
         '500':
           $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+    post:
+      summary: Create document types for a sender
+      description: |
+        Registers one or more document types for a specific sender. If the sender does not exist, the implementation should create the sender automatically.
+      operationId: createDocumentTypesForSender
+      tags:
+        - Document Types
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/senderId"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/Idempotency-Key"
+      requestBody:
+        $ref: "#/components/requestBodies/createDocumentTypes"
+      responses:
+        '201':
+          $ref: "#/components/responses/CREATED_201_DocumentTypes"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/owners/{owner-id}/document-types:
+
+    get:
+      summary: Get document types by owner
+      description: |
+        Returns the document types available for a specific document owner, regardless of sender.
+      operationId: getDocumentTypesForOwner
+      tags:
+        - Document Types
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ownerId"
+        - $ref: "#/components/parameters/Storage-System"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentTypeDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  #####################################################
+  # Documents
+  #####################################################
+
+  /v1/documents:
+
+    post:
+      summary: Create a single document
+      description: |
+        Creates a single document and returns the created document identifier.
+      operationId: createDocument
+      tags:
+        - Documents
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Storage-System"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/Idempotency-Key"
+      requestBody:
+        $ref: "#/components/requestBodies/documentInitiation"
+      responses:
+        '201':
+          $ref: "#/components/responses/CREATED_201_Document"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+    get:
+      summary: Search documents
+      description: |
+        Returns a filtered list of documents. Use `GET /v1/documents/{document-id}` for retrieval of a single document by identifier.
+      operationId: searchDocuments
+      tags:
+        - Documents
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Storage-System"
+        - $ref: "#/components/parameters/senderIdOptionalQuery"
+        - $ref: "#/components/parameters/ownerIdQuery"
+        - $ref: "#/components/parameters/documentTypeCode"
+        - $ref: "#/components/parameters/batchStatusQuery"
+        - $ref: "#/components/parameters/dateFrom"
+        - $ref: "#/components/parameters/dateTo"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/ordering"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentListWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/documents/{document-id}:
+
+    get:
+      summary: Get a single document
+      description: |
+        Returns a single document by identifier. If not specified, the implementation may assume the default storage code (e.g. Ark).
+      operationId: getDocumentById
+      tags:
+        - Documents
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/documentIdPathParameter"
+        - $ref: "#/components/parameters/Storage-System"
+        - $ref: "#/components/parameters/ownerIdRequiredQuery"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_DocumentWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  #####################################################
+  # Batches
+  #####################################################
+
+  /v1/batches:
+
+    get:
+      summary: Search batches
+      description: |
+        Returns a filtered, paginated list of batches.
+      operationId: searchBatches
+      tags:
+        - Batches
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/senderIdOptionalQuery"
+        - $ref: "#/components/parameters/documentTypeCode"
+        - $ref: "#/components/parameters/batchStatusQuery"
+        - $ref: "#/components/parameters/dateFrom"
+        - $ref: "#/components/parameters/dateTo"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/itemsPerPage"
+        - $ref: "#/components/parameters/ordering"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_BatchList"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+    post:
+      summary: Create a batch
+      description: |
+        Creates a new batch and uploads one or more documents.
+      operationId: createBatch
+      tags:
+        - Batches
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Storage-System"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/Idempotency-Key"
+      requestBody:
+        $ref: "#/components/requestBodies/batchInitiation"
+      responses:
+        '201':
+          $ref: "#/components/responses/CREATED_201_BatchWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/batches/{batch-id}:
+
+    get:
+      summary: Get a single batch
+      description: |
+        Returns a single batch by batch identifier.
+      operationId: getBatchById
+      tags:
+        - Batches
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/batchIdPath"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_BatchWithStatusDetails"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+  /v1/batches/{batch-id}/items:
+
+    get:
+      summary: Get items in a batch
+      description: |
+        Returns a paginated list of document identifiers within a batch.
+      operationId: getBatchItems
+      tags:
+        - Batches
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/batchIdPath"
+        - $ref: "#/components/parameters/pageOptional"
+        - $ref: "#/components/parameters/itemsPerPageOptional"
+        - $ref: "#/components/parameters/ordering"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_BatchItems"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+
+  #####################################################
+  # Cross-References
+  #####################################################
 
   /v1/crossreferences:
 
@@ -353,11 +431,12 @@ paths:
       description: Create an array of new cross-references between documents and some other objects (such as claims, credit transfers and payment requests).
       operationId: createCrossReferences
       tags:
-        - Cross-Reference Service (CRS)
+        - Cross-References
       security:
         - {}
         - BearerAuthOAuth: []
       parameters:
+        - $ref: "#/components/parameters/Storage-System"
         - $ref: "#/components/parameters/X-Request-ID"
         - $ref: "#/components/parameters/USR-IP-Address_optional"
         - $ref: "#/components/parameters/Idempotency-Key"
@@ -372,14 +451,6 @@ paths:
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
           $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
         '500':
@@ -387,38 +458,34 @@ paths:
         '503':
           $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
 
-    put:
-      summary: Update cross-references
-      description: Updates an array of cross-references between documents and other objects.
-      operationId: updateCrossReferences
+    delete:
+      summary: Delete cross-references
+      description: |
+        Deletes an array of cross-references. Each item identifies a cross-reference
+        by its document ID, key type and key. A single optional externalEventId applies
+        to all items in the batch.
+      operationId: deleteCrossReferences
       tags:
-        - Cross-Reference Service (CRS)
+        - Cross-References
       security:
         - {}
         - BearerAuthOAuth: []
       parameters:
+        - $ref: "#/components/parameters/Storage-System"
         - $ref: "#/components/parameters/X-Request-ID"
         - $ref: "#/components/parameters/USR-IP-Address_optional"
         - $ref: "#/components/parameters/Idempotency-Key"
       requestBody:
-        $ref: "#/components/requestBodies/updateCrossReferences"
+        $ref: "#/components/requestBodies/deleteCrossReferences"
       responses:
         '200':
-          $ref: "#/components/responses/OK_200_UpdateCrossReferences"
+          $ref: "#/components/responses/OK_200_DeleteCrossReferences"
         '400':
           $ref: "#/components/responses/BAD_REQUEST_400"
         '401':
           $ref: "#/components/responses/UNAUTHORIZED_401"
         '403':
           $ref: "#/components/responses/FORBIDDEN_403"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
           $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
         '500':
@@ -434,7 +501,7 @@ paths:
         Returns all cross-references identified by key type and key.
       operationId: getCrossReferencesByKeyTypeAndKey
       tags:
-        - Cross-Reference Service (CRS)
+        - Cross-References
       security:
         - {}
         - BearerAuthOAuth: []
@@ -443,7 +510,7 @@ paths:
         - $ref: "#/components/parameters/USR-IP-Address_optional"
         - $ref: "#/components/parameters/keyTypePathParameter"
         - $ref: "#/components/parameters/keyPathParameter"
-        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/Storage-System"
       responses:
         '200':
           $ref: "#/components/responses/OK_200_CrossReferencesByKey"
@@ -455,12 +522,6 @@ paths:
           $ref: "#/components/responses/FORBIDDEN_403"
         '404':
           $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
           $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
         '500':
@@ -473,10 +534,10 @@ paths:
     get:
       summary: Get cross-references for a document
       description: |
-        Returns cross-references for a single document. The document store may be supplied if needed; otherwise the implementation may assume the default store.
+        Returns cross-references for a single document. The storage code may be supplied if needed; otherwise the implementation may assume the default store.
       operationId: getCrossReferencesForDocument
       tags:
-        - Cross-Reference Service (CRS)
+        - Cross-References
       security:
         - {}
         - BearerAuthOAuth: []
@@ -484,7 +545,7 @@ paths:
         - $ref: "#/components/parameters/X-Request-ID"
         - $ref: "#/components/parameters/USR-IP-Address_optional"
         - $ref: "#/components/parameters/documentIdPathParameter"
-        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/Storage-System"
         - $ref: "#/components/parameters/pageOptional"
         - $ref: "#/components/parameters/itemsPerPageOptional"
       responses:
@@ -498,12 +559,6 @@ paths:
           $ref: "#/components/responses/FORBIDDEN_403"
         '404':
           $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
           $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
         '500':
@@ -513,13 +568,87 @@ paths:
 
   /v1/documents/{document-id}/crossreferences/{key-type}/{key}:
 
+    get:
+      summary: Get a single cross-reference for a document
+      description: |
+        Returns a single cross-reference identified by document, key type and key.
+      operationId: getCrossReferenceForDocument
+      tags:
+        - Cross-References
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/documentIdPathParameter"
+        - $ref: "#/components/parameters/keyTypePathParameter"
+        - $ref: "#/components/parameters/keyPathParameter"
+        - $ref: "#/components/parameters/Storage-System"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_CrossReference"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
+    patch:
+      summary: Update a cross-reference for a document
+      description: |
+        Updates a single cross-reference identified by document, key type and key.
+        Only the supplied fields are modified; omitted fields remain unchanged.
+      operationId: updateCrossReferenceForDocument
+      tags:
+        - Cross-References
+      security:
+        - {}
+        - BearerAuthOAuth: []
+      parameters:
+        - $ref: "#/components/parameters/documentIdPathParameter"
+        - $ref: "#/components/parameters/keyTypePathParameter"
+        - $ref: "#/components/parameters/keyPathParameter"
+        - $ref: "#/components/parameters/Storage-System"
+        - $ref: "#/components/parameters/X-Request-ID"
+        - $ref: "#/components/parameters/USR-IP-Address_optional"
+        - $ref: "#/components/parameters/Idempotency-Key"
+      requestBody:
+        $ref: "#/components/requestBodies/updateCrossReference"
+      responses:
+        '200':
+          $ref: "#/components/responses/OK_200_CrossReference"
+        '400':
+          $ref: "#/components/responses/BAD_REQUEST_400"
+        '401':
+          $ref: "#/components/responses/UNAUTHORIZED_401"
+        '403':
+          $ref: "#/components/responses/FORBIDDEN_403"
+        '404':
+          $ref: "#/components/responses/NOT_FOUND_404"
+        '429':
+          $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
+        '500':
+          $ref: "#/components/responses/INTERNAL_SERVER_ERROR_500"
+        '503':
+          $ref: "#/components/responses/SERVICE_UNAVAILABLE_503"
+
     delete:
       summary: Delete a cross-reference for a document
       description: |
-        Deletes a cross-reference identified by document, key type and key. The document store may be supplied if needed; otherwise the implementation may assume the default store.
+        Deletes a cross-reference identified by document, key type and key. The storage code may be supplied if needed; otherwise the implementation may assume the default store.
       operationId: deleteCrossReferenceForDocument
       tags:
-        - Cross-Reference Service (CRS)
+        - Cross-References
       security:
         - {}
         - BearerAuthOAuth: []
@@ -530,11 +659,11 @@ paths:
         - $ref: "#/components/parameters/documentIdPathParameter"
         - $ref: "#/components/parameters/keyTypePathParameter"
         - $ref: "#/components/parameters/keyPathParameter"
-        - $ref: "#/components/parameters/documentStoreQueryParameter"
+        - $ref: "#/components/parameters/Storage-System"
         - $ref: "#/components/parameters/externalEventId"
       responses:
         '200':
-          $ref: "#/components/responses/OK_200_DeleteCrossReferences"
+          $ref: "#/components/responses/OK_200_DeleteCrossReference"
         '400':
           $ref: "#/components/responses/BAD_REQUEST_400"
         '401':
@@ -543,14 +672,6 @@ paths:
           $ref: "#/components/responses/FORBIDDEN_403"
         '404':
           $ref: "#/components/responses/NOT_FOUND_404"
-        '405':
-          $ref: "#/components/responses/METHOD_NOT_ALLOWED_405"
-        '408':
-          $ref: "#/components/responses/REQUEST_TIMEOUT_408"
-        '409':
-          $ref: "#/components/responses/CONFLICT_409"
-        '415':
-          $ref: "#/components/responses/UNSUPPORTED_MEDIA_TYPE_415"
         '429':
           $ref: "#/components/responses/TOO_MANY_REQUESTS_429"
         '500':
@@ -600,6 +721,16 @@ components:
         type: string
         format: uuid
 
+    Storage-System:
+      name: Storage-System
+      in: header
+      description: |
+        Storage system. If omitted, defaults to "Ark".
+      required: false
+      schema:
+        $ref: "#/components/schemas/storageCode"
+        default: "Ark"
+
     USR-IP-Address_optional:
       name: USR-IP-Address
       in: header
@@ -611,20 +742,20 @@ components:
       required: false
       example: 192.168.8.78
 
-    documentProcessIdPath:
-      name: document-process-id
+    batchIdPath:
+      name: batch-id
       in: path
       description: |
-        Document process id in path.
+        Batch id in path.
       required: true
       schema:
         $ref: "#/components/schemas/uuid"
         
-    documentProcessIdQuery:
-      name: documentProcessId
+    batchIdQuery:
+      name: batchId
       in: query
       description: |
-        Document process id.
+        Batch id.
       required: false
       schema:
         $ref: "#/components/schemas/uuid"
@@ -637,15 +768,6 @@ components:
       required: false
       schema:
         $ref: "#/components/schemas/uuid"
-
-    documentStore:
-      name: document-store
-      description: |
-        The name of the store where the document is located. 
-      in: path
-      required: true
-      schema:
-        $ref: "#/components/schemas/documentStore"
 
     page:
       name: page
@@ -687,38 +809,56 @@ components:
         type: string
         format: date
 
-    senderKennitalaQuery:
-      name: senderKennitala
+    senderIdQuery:
+      name: senderId
       in: query
       description: |
-        Kennitala of the document sender for filtering.
+        Identifier (kennitala) of the document sender for filtering.
       required: true
       schema:
         $ref: "#/components/schemas/kennitala"
 
-    senderKennitala:
-      name: sender-kennitala
-      in: path
-      description: |
-        Kennitala of the document sender.
-      required: true
-      schema:
-        $ref: "#/components/schemas/kennitala"
-
-    ownerKennitalaQuery:
-      name: ownerKennitala
+    senderIdOptionalQuery:
+      name: senderId
       in: query
       description: |
-        Kennitala of the document owner for filtering.
+        Identifier (kennitala) of the document sender for filtering.
       required: false
       schema:
         $ref: "#/components/schemas/kennitala"
 
-    ownerKennitalaRequiredQuery:
-      name: ownerKennitala
+    senderId:
+      name: sender-id
+      in: path
+      description: |
+        Identifier (kennitala) of the document sender.
+      required: true
+      schema:
+        $ref: "#/components/schemas/kennitala"
+
+    ownerId:
+      name: owner-id
+      in: path
+      description: |
+        Identifier (kennitala) of the document owner.
+      required: true
+      schema:
+        $ref: "#/components/schemas/kennitala"
+
+    ownerIdQuery:
+      name: ownerId
       in: query
       description: |
-        Kennitala of the document owner.
+        Identifier (kennitala) of the document owner for filtering.
+      required: false
+      schema:
+        $ref: "#/components/schemas/kennitala"
+
+    ownerIdRequiredQuery:
+      name: ownerId
+      in: query
+      description: |
+        Identifier (kennitala) of the document owner.
       required: true
       schema:
         $ref: "#/components/schemas/kennitala"
@@ -734,14 +874,14 @@ components:
         minLength: 1
         maxLength: 10
 
-    status:
+    batchStatusQuery:
       name: status
       in: query
       description: |
-        Process status
+        Filter by batch status.
       required: false
       schema:
-        $ref: "#/components/schemas/processStatus"
+        $ref: "#/components/schemas/batchStatus"
       
     Idempotency-Key:
       name: Idempotency-Key
@@ -779,20 +919,10 @@ components:
       description: |
         The ID of document related to the object in question. The ID is a unique identifier for the document in its source system.
       required: true
-      example: "00ec5225-8a64-48a2-b6bf-f4ef558b27df"
+      example: "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324"
       schema:
         $ref: "#/components/schemas/documentId"
       
-    documentStorePathParameter:
-      name: document-store
-      in: path
-      description: |
-        Document data storage system. The value is one of the following:
-      required: true
-      example: Ark
-      schema:
-        $ref: "#/components/schemas/documentStore"
-
     key:
       name: key
       in: query
@@ -820,21 +950,10 @@ components:
       description: |
         The ID of document related to the object in question. The ID is a unique identifier for the document in its source system.
       required: false
-      example: "00ec5225-8a64-48a2-b6bf-f4ef558b27df"
+      example: "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324"
       schema:
         $ref: "#/components/schemas/documentId"
       
-    documentStoreQueryParameter:
-      name: documentStore
-      in: query
-      description: |
-        Document data storage system. The value is one of the following.
-        If omitted, default value is `Ark`.
-      required: false
-      example: Ark
-      schema:
-        $ref: "#/components/schemas/documentStore"
-
     documentCategory:
       name: documentCategory
       in: query
@@ -893,6 +1012,20 @@ components:
       schema:
         $ref: "#/components/schemas/pagingItemsPerPage"
 
+    ordering:
+      name: ordering
+      in: query
+      description: |
+        Sort order for the results. Default is descending.
+      required: false
+      example: DESC
+      schema:
+        type: string
+        enum:
+          - "ASC"
+          - "DESC"
+        default: "DESC"
+
   schemas:
     #####################################################
     # Predefined Schemas
@@ -909,46 +1042,6 @@ components:
       minimum: 1
 
     #####################################################
-    # _links
-    #####################################################
-
-    hrefType:
-      description: Link to a resource.
-      type: object
-      properties:
-        href:
-          $ref: "#/components/schemas/hrefEntry"
-
-    hrefEntry:
-      description: Link to a resource.
-      type: string
-
-    _linksAll:
-      description: |
-        A _link object with all available link types.
-      type: object
-      additionalProperties:
-        $ref: "#/components/schemas/hrefType"
-      properties:
-        confirmation:
-          $ref: "#/components/schemas/hrefType"
-        self:
-          $ref: "#/components/schemas/hrefType"
-        status:
-          $ref: "#/components/schemas/hrefType"
-        scaStatus:
-          $ref: "#/components/schemas/hrefType"
-        first:
-          $ref: "#/components/schemas/hrefType"
-        next:
-          $ref: "#/components/schemas/hrefType"
-        previous:
-          $ref: "#/components/schemas/hrefType"
-        last:
-          $ref: "#/components/schemas/hrefType"
-        download:
-          $ref: "#/components/schemas/hrefType"
-
     kennitala:
       description: |
         An Icelandic national ID, either issued for individuals by the Registers Iceland (Þjóðskrá) or the 
@@ -957,7 +1050,7 @@ components:
         https://en.wikipedia.org/wiki/Icelandic_identification_number
       type: string
       pattern: '[0-9]{10}'
-      example: "1111111119"
+      example: "1909791489"
 
     documentTypeDetails:
       description: |
@@ -980,11 +1073,27 @@ components:
         durableMedia:
           description: |
             Control flag describing if document type is durable media. If document type
-            is durable media then any document process using this code can not be updated.
+            is durable media then any batch using this code can not be updated.
           type: boolean
         description:
           description: |
             Long description for the document
+          type: string
+          maxLength: 140
+        fileType:
+          description: |
+            Accepted file type for this document type.
+          type: string
+          enum:
+            - "XML"
+            - "PDF"
+        categoryCode:
+          description: |
+            Document category code.
+          $ref: "#/components/schemas/documentCategory"
+        categoryDescription:
+          description: |
+            Human-readable description of the document category.
           type: string
           maxLength: 140
 
@@ -995,19 +1104,109 @@ components:
       items:
         $ref: "#/components/schemas/documentTypeDetails"
 
+    documentTypeCreation:
+      description: |
+        Document type creation request item.
+      type: object
+      required:
+        - fileType
+        - categoryCode
+      properties:
+        fileType:
+          description: |
+            Accepted file type for this document type.
+          type: string
+          enum:
+            - "XML"
+            - "PDF"
+        categoryCode:
+          $ref: "#/components/schemas/documentCategory"
+        email:
+          description: |
+            Email address associated with this document type.
+          type: string
+          format: email
+
+    documentTypeCreationList:
+      description: |
+        List of document types to create.
+      type: array
+      minItems: 1
+      items:
+        $ref: "#/components/schemas/documentTypeCreation"
+
+    documentTypeCreationFailure:
+      description: |
+        A document type that failed to be created, with the reason for failure.
+      type: object
+      required:
+        - fileType
+        - categoryCode
+        - failureReason
+      properties:
+        fileType:
+          description: |
+            Accepted file type for this document type.
+          type: string
+          enum:
+            - "XML"
+            - "PDF"
+        categoryCode:
+          $ref: "#/components/schemas/documentCategory"
+        failureReason:
+          description: Description of why the creation failed.
+          type: string
+          example: "Document type already exists for this sender."
+
+    documentTypeCreationResult:
+      description: |
+        Result of a batch document type creation request.
+      type: object
+      required:
+        - created
+        - failed
+      properties:
+        created:
+          type: array
+          items:
+            $ref: "#/components/schemas/documentTypeDetails"
+        failed:
+          type: array
+          items:
+            $ref: "#/components/schemas/documentTypeCreationFailure"
+
+    documentInitiationDetails:
+      description: |
+        Single document creation payload with document type and file content.
+      allOf:
+        - type: object
+          required:
+            - senderId
+            - documentTypeCode
+          properties:
+            senderId:
+              description: |
+                Identifier (kennitala) of the document sender.
+              $ref: "#/components/schemas/kennitala"
+            documentTypeCode:
+              description: |
+                Document type code as returned by GET /v1/senders/{sender-id}/document-types
+              type: string
+              minLength: 1
+              maxLength: 10
+        - $ref: "#/components/schemas/fileDetails"
+
     fileDetails:
       description: |
         Document details.
       oneOf:
         - $ref: "#/components/schemas/fileDetailsXML"
         - $ref: "#/components/schemas/fileDetailsPDF"
-        - $ref: "#/components/schemas/fileDetailsLINK"
       discriminator:
         propertyName: fileType
         mapping:
           XML: "#/components/schemas/fileDetailsXML"
           PDF: "#/components/schemas/fileDetailsPDF"
-          LINK: "#/components/schemas/fileDetailsLINK"
 
     fileDescription:
       description: |
@@ -1018,15 +1217,27 @@ components:
     fileDetailsCommon:
       type: object
       required:
-        - id
-        - receiverKennitala
+        - externalId
+        - ownerId
       properties:
-        id:
-          $ref: "#/components/schemas/uuid"
+        externalId:
+          description: |
+            External identifier used to link the document with the sender's own systems.
+          type: string
+        ownerId:
+          $ref: "#/components/schemas/kennitala"
+        effectiveDate:
+          description: |
+            The effective date of the document. If omitted, the implementation should default to today's date.
+          type: string
+          format: date
+        reference:
+          description: |
+            Free text reference set by the sender.
+          type: string
+          maxLength: 200
         description:
           $ref: "#/components/schemas/fileDescription"
-        receiverKennitala:
-          $ref: "#/components/schemas/kennitala"
 
     fileTypeXML:
       type: string
@@ -1037,11 +1248,6 @@ components:
       type: string
       enum:
         - "PDF"
-
-    fileTypeLINK:
-      type: string
-      enum:
-        - "LINK"
 
     filePayloadXML:
       type: object
@@ -1067,18 +1273,7 @@ components:
           description: The PDF file in the form of base64 encoded characters.
           type: string
           format: byte
-
-    filePayloadLINK:
-      type: object
-      required:
-        - fileType
-        - file
-      properties:
-        fileType:
-          $ref: "#/components/schemas/fileTypeLINK"
-        file:
-          description: Link or external reference to the file as a plain string.
-          type: string
+          maxLength: 4194304
 
     fileDetailsXML:
       description: |
@@ -1094,63 +1289,64 @@ components:
         - $ref: "#/components/schemas/fileDetailsCommon"
         - $ref: "#/components/schemas/filePayloadPDF"
 
-    fileDetailsLINK:
+    batchDetails:
       description: |
-        LINK file details where the payload is a string reference to the file.
-      allOf:
-        - $ref: "#/components/schemas/fileDetailsCommon"
-        - $ref: "#/components/schemas/filePayloadLINK"
-
-    documentProcessDetails:
-      description: |
-        Document process details.
+        Batch creation payload. The senderId applies to all documents in the batch.
       type: object
       required:
-        - id
-        - name
-        - senderKennitala
-        - documentTypeCode
-        - files
+        - senderId
+        - documents
       properties:
-        id:
-          $ref: "#/components/schemas/uuid"
-        name:
-          description: Short description for the document process
-          type: string
-          maxLength: 70
-        description:
+        senderId:
           description: |
-            The file description usually in this format: "<Company name as sender> - <Document type>"
-          type: string
-          maxLength: 140
-        senderKennitala:
+            Identifier (kennitala) of the document sender. Applies to all documents in the batch.
           $ref: "#/components/schemas/kennitala"
-        documentTypeCode:
-          description: |
-            Document type code retrieved from {sender-kennitala}/types
-          type: string
-          minLength: 1
-          maxLength: 10
-        files:
+        documents:
           type: array
+          minItems: 1
           items:
-            $ref: "#/components/schemas/fileDetails"
+            $ref: "#/components/schemas/batchDocumentItem"
 
-    processStatus:
+    batchDocumentItem:
       description: |
-        Process status. The value is one of the following:
-        - "received":             The document(s) has been received but processing has not started
-        - "inProgress":           The document(s) is being processed
-        - "completed":            The document(s) has been processed
-        - "completedWithErrors":  The document(s) has been processed with errors
-        - "failed":               Failed to process document
+        A single document within a batch creation request.
+      allOf:
+        - type: object
+          required:
+            - documentTypeCode
+          properties:
+            documentTypeCode:
+              description: |
+                Document type code as returned by GET /v1/senders/{sender-id}/document-types
+              type: string
+              minLength: 1
+              maxLength: 10
+        - $ref: "#/components/schemas/fileDetails"
+
+    batchCreated:
+      description: |
+        Response from a batch creation request.
+      type: object
+      required:
+        - batchId
+      properties:
+        batchId:
+          description: Identifier of the created batch. Use this to track batch status and retrieve items.
+          type: string
+
+    batchStatus:
+      description: |
+        Batch status. The value is one of the following:
+        - "OnHold":               The batch is pending and has not started processing
+        - "InProgress":           The batch is being processed
+        - "Completed":            The batch has been processed
+        - "CompletedWithErrors":  The batch has been processed with errors
       type: string
       enum:
-        - "received"
-        - "inProgress"
-        - "completed"
-        - "completedWithErrors"
-        - "failed"
+        - "OnHold"
+        - "InProgress"
+        - "Completed"
+        - "CompletedWithErrors"
 
     fileWithStatusDetails:
       description: |
@@ -1158,26 +1354,42 @@ components:
       oneOf:
         - $ref: "#/components/schemas/fileWithStatusDetailsXML"
         - $ref: "#/components/schemas/fileWithStatusDetailsPDF"
-        - $ref: "#/components/schemas/fileWithStatusDetailsLINK"
       discriminator:
         propertyName: fileType
         mapping:
           XML: "#/components/schemas/fileWithStatusDetailsXML"
           PDF: "#/components/schemas/fileWithStatusDetailsPDF"
-          LINK: "#/components/schemas/fileWithStatusDetailsLINK"
 
     fileWithStatusCommon:
       allOf:
         - $ref: "#/components/schemas/fileDetailsCommon"
         - type: object
           required:
+            - id
+            - senderId
+            - senderName
             - status
             - isCrossReferenced
+            - effectiveDate
           properties:
+            id:
+              description: |
+                Unique document identifier. For Ark storage this is a composite key in the format
+                `{ownerId}:{senderId}:{externalId}:{YYYYMMDD}`. For RBS storage this is a UUID.
+              $ref: "#/components/schemas/documentId"
+            senderId:
+              description: |
+                Identifier (kennitala) of the document sender.
+              $ref: "#/components/schemas/kennitala"
+            senderName:
+              description: |
+                Name of the document sender.
+              type: string
+              maxLength: 140
             status:
-              $ref: "#/components/schemas/processStatus"
+              $ref: "#/components/schemas/batchStatus"
             statusMessage:
-              description: Process status message
+              description: Batch status message
               type: string
               maxLength: 250
             isCrossReferenced:
@@ -1201,14 +1413,6 @@ components:
         fileType:
           $ref: "#/components/schemas/fileTypePDF"
 
-    fileTypeTagLINK:
-      type: object
-      required:
-        - fileType
-      properties:
-        fileType:
-          $ref: "#/components/schemas/fileTypeLINK"
-
     fileWithStatusDetailsXML:
       allOf:
         - $ref: "#/components/schemas/fileWithStatusCommon"
@@ -1219,28 +1423,49 @@ components:
         - $ref: "#/components/schemas/fileWithStatusCommon"
         - $ref: "#/components/schemas/fileTypeTagPDF"
 
-    fileWithStatusDetailsLINK:
+    documentDetail:
+      description: |
+        Full document details including file content. Returned by the single document retrieval endpoint.
+      oneOf:
+        - $ref: "#/components/schemas/documentDetailXML"
+        - $ref: "#/components/schemas/documentDetailPDF"
+      discriminator:
+        propertyName: fileType
+        mapping:
+          XML: "#/components/schemas/documentDetailXML"
+          PDF: "#/components/schemas/documentDetailPDF"
+
+    documentDetailXML:
+      description: |
+        Full document details with XML file content.
       allOf:
         - $ref: "#/components/schemas/fileWithStatusCommon"
-        - $ref: "#/components/schemas/fileTypeTagLINK"
+        - $ref: "#/components/schemas/filePayloadXML"
 
-    documentProcessWithStatusDetails:
+    documentDetailPDF:
       description: |
-        Document process details.
+        Full document details with PDF file content.
+      allOf:
+        - $ref: "#/components/schemas/fileWithStatusCommon"
+        - $ref: "#/components/schemas/filePayloadPDF"
+
+    batchWithStatusDetails:
+      description: |
+        Batch status details for a single batch.
       type: object
       required:
         - id
-        - name
-        - senderKennitala
+        - senderId
         - documentTypeCode
         - status
-        - files
+        - createdDate
+        - itemCount
       properties:
         id:
-          # Unique ID of the process, as determined by the initiating party.
+          # Unique ID of the batch, as determined by the initiating party.
           $ref: "#/components/schemas/uuid"
         name:
-          description: Short description for the process
+          description: Short description for the batch
           type: string
           maxLength: 70
         description:
@@ -1248,60 +1473,64 @@ components:
             The file description usually in this format: "<Company name as sender> - <Document type>"
           type: string
           maxLength: 140
-        senderKennitala:
+        senderId:
           $ref: "#/components/schemas/kennitala"
         documentTypeCode:
           description: |
-            Document type code retrieved from {sender-kennitala}/types
+            Document type code as returned by GET /v1/senders/{sender-id}/document-types
           type: string
           minLength: 1
           maxLength: 10
         status:
-          $ref: "#/components/schemas/processStatus"
-        files:
-          type: array
-          items:
-            $ref: "#/components/schemas/fileWithStatusDetails"
+          $ref: "#/components/schemas/batchStatus"
+        createdBy:
+          description: Username of the batch creator.
+          type: string
+        createdDate:
+          description: Timestamp when the batch was created.
+          type: string
+          format: date-time
+        itemCount:
+          description: Total number of items in the batch.
+          type: integer
+          minimum: 0
+        itemSuccessCount:
+          description: Number of items that were successfully processed. Only returned when the batch has completed.
+          type: integer
+          minimum: 0
+        itemErrorCount:
+          description: Number of items that failed processing. Only returned when the batch has completed.
+          type: integer
+          minimum: 0
 
-    documentProcessWithStatusSummary:
-      description: |
-        Document process summary details for list responses.
+    batchItem:
       type: object
       required:
-        - id
-        - name
-        - senderKennitala
-        - documentTypeCode
+        - documentId
         - status
       properties:
-        id:
-          $ref: "#/components/schemas/uuid"
-        name:
-          description: Short description for the process
-          type: string
-          maxLength: 70
-        description:
-          description: |
-            The file description usually in this format: "<Company name as sender> - <Document type>"
-          type: string
-          maxLength: 140
-        senderKennitala:
-          $ref: "#/components/schemas/kennitala"
-        documentTypeCode:
-          description: |
-            Document type code retrieved from {sender-kennitala}/types
-          type: string
-          minLength: 1
-          maxLength: 10
+        documentId:
+          $ref: "#/components/schemas/documentId"
         status:
-          $ref: "#/components/schemas/processStatus"
+          $ref: "#/components/schemas/batchStatus"
+        statusMessage:
+          description: Status message
+          type: string
+          maxLength: 250
 
-    documentProcessWithStatusList:
+    batchItemList:
       description: |
-        List of document processes with summary details.
+        List of batch items.
       type: array
       items:
-        $ref: "#/components/schemas/documentProcessWithStatusSummary"
+        $ref: "#/components/schemas/batchItem"
+
+    batchList:
+      description: |
+        List of batches.
+      type: array
+      items:
+        $ref: "#/components/schemas/batchWithStatusDetails"
 
     documentWithStatusList:
       description: |
@@ -1309,6 +1538,21 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/fileWithStatusDetails"
+
+    documentCreated:
+      description: |
+        Response returned when a single document is created.
+      type: object
+      required:
+        - documentId
+      properties:
+        documentId:
+          description: |
+            The unique identifier assigned to the created document.
+            Composite key of ownerId, senderId, externalId and effectiveDate joined by colon.
+            Format: `{ownerId}:{senderId}:{externalId}:{effectiveDate}`
+          type: string
+          example: "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324"
 
     uuid:
       description: Unique Identifier 
@@ -1323,6 +1567,118 @@ components:
       items:
         $ref: "#/components/schemas/crossReference"
 
+    crossReferenceFailure:
+      description: |
+        A cross-reference that failed to be processed, with the reason for failure.
+      type: object
+      required:
+        - keyType
+        - key
+        - document
+        - failureReason
+      properties:
+        key:
+          $ref: "#/components/schemas/key"
+        keyType:
+          $ref: "#/components/schemas/keyType"
+        document:
+          description: |
+            Document details identifying the failed cross-reference.
+          type: object
+          nullable: false
+          required:
+            - id
+          properties:
+            id:
+              $ref: "#/components/schemas/documentId"
+        failureReason:
+          description: Description of why the operation failed.
+          type: string
+          example: "Cross-reference already exists."
+
+    crossReferenceCreationResult:
+      description: |
+        Result of a batch cross-reference creation. Contains both successfully
+        created items and items that failed.
+      type: object
+      required:
+        - created
+        - failed
+      properties:
+        created:
+          type: array
+          items:
+            $ref: "#/components/schemas/crossReference"
+        failed:
+          type: array
+          items:
+            $ref: "#/components/schemas/crossReferenceFailure"
+
+    crossReferenceDeletionResult:
+      description: |
+        Result of a batch cross-reference deletion. Contains both successfully
+        deleted items and items that failed.
+      type: object
+      required:
+        - deleted
+        - failed
+      properties:
+        deleted:
+          type: array
+          items:
+            $ref: "#/components/schemas/crossReferenceIdentifier"
+        failed:
+          type: array
+          items:
+            $ref: "#/components/schemas/crossReferenceFailure"
+
+    crossReferenceUpdate:
+      description: |
+        Fields that may be updated on an existing cross-reference.
+        All properties are optional; only supplied fields are changed.
+      type: object
+      properties:
+        category:
+          $ref: "#/components/schemas/documentCategory"
+        description:
+          $ref: "#/components/schemas/documentDescription"
+        effectiveDate:
+          $ref: "#/components/schemas/documentEffectiveDate"
+        externalEventId:
+          $ref: "#/components/schemas/externalEventId"
+
+    crossReferenceIdentifier:
+      description: |
+        Identifies a single cross-reference by its document ID, key type and key.
+      type: object
+      required:
+        - documentId
+        - keyType
+        - key
+      properties:
+        documentId:
+          $ref: "#/components/schemas/documentId"
+        keyType:
+          $ref: "#/components/schemas/keyType"
+        key:
+          $ref: "#/components/schemas/key"
+
+    crossReferenceDeletionRequest:
+      description: |
+        Request to delete one or more cross-references. A single optional
+        externalEventId applies to all items in the batch.
+      type: object
+      required:
+        - crossReferences
+      properties:
+        externalEventId:
+          $ref: "#/components/schemas/externalEventId"
+        crossReferences:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/crossReferenceIdentifier"
+
     crossReference:
       description: |
         Detail information for a single cross-reference.
@@ -1330,23 +1686,28 @@ components:
       required:
         - key
         - keyType
-        - documentId
-        - documentStore
+        - document
       properties:
         key:
           $ref: "#/components/schemas/key"
         keyType:
           $ref: "#/components/schemas/keyType"
-        documentId:
-          $ref: "#/components/schemas/documentId"
-        documentStore:
-          $ref: "#/components/schemas/documentStore"
-        documentCategory:
-          $ref: "#/components/schemas/documentCategory"
-        documentDescription:
-          $ref: "#/components/schemas/documentDescription"
-        documentEffectiveDate:
-          $ref: "#/components/schemas/documentEffectiveDate"
+        document:
+          description: |
+            Document details associated with this cross-reference.
+          type: object
+          nullable: false
+          required:
+            - id
+          properties:
+            id:
+              $ref: "#/components/schemas/documentId"
+            category:
+              $ref: "#/components/schemas/documentCategory"
+            description:
+              $ref: "#/components/schemas/documentDescription"
+            effectiveDate:
+              $ref: "#/components/schemas/documentEffectiveDate"
         externalEventId:
           $ref: "#/components/schemas/externalEventId"
 
@@ -1370,11 +1731,11 @@ components:
       description: |
         The ID of document related to the object in question. The ID is a unique identifier for the document in its source system.
       type: string
-      example: "00ec5225-8a64-48a2-b6bf-f4ef558b27df"
+      example: "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324"
 
-    documentStore:
+    storageCode:
       description: |
-        Document data storage system. The value is one of the following:
+        Storage system code.
       type: string
       enum: 
         - "Ark"
@@ -1428,244 +1789,83 @@ components:
     # Standard messages
     #####################################################
 
-    messageCategory:
-      description: Category of the message category.
-      type: string
-      enum:
-        - "ERROR"
-        - "WARNING"
 
     MessageCode400:
-      description: Message codes defined for HTTP Error code 400 (BAD_REQUEST).
+      description: Message codes for HTTP error code 400 (BAD_REQUEST).
       type: string
       enum:
-        - "FORMAT_ERROR"              #gen
-        - "PARAMETER_NOT_CONSISTENT"  #gen
-        - "PARAMETER_NOT_SUPPORTED"   #gen
-        - "SERVICE_INVALID"           #gen
-        - "RESOURCE_UNKNOWN"          #gen
-        - "RESOURCE_EXPIRED"          #gen
-        - "RESOURCE_BLOCKED"          #gen
-        - "TIMESTAMP_INVALID"         #gen
-        - "PERIOD_INVALID"            #gen
-        - "SESSIONS_NOT_SUPPORTED"    #IOBWS
+        - "FORMAT_ERROR"
+        - "VALIDATION_ERROR"
 
     MessageCode401:
-      description: Message codes defined for HTTP Error code 401 (UNAUTHORIZED).
+      description: Message codes for HTTP error code 401 (UNAUTHORIZED).
       type: string
       enum:
-        - "CERTIFICATE_INVALID"       #gen
-        - "ROLE_INVALID"              #gen
-        - "CERTIFICATE_EXPIRED"       #gen
-        - "CERTIFICATE_BLOCKED"       #gen
-        - "CERTIFICATE_REVOKE"        #gen
-        - "CERTIFICATE_MISSING"       #gen
-        - "SIGNATURE_INVALID"         #gen
-        - "SIGNATURE_MISSING"         #gen
-        - "CORPORATE_ID_INVALID"      #gen
-        - "USR_CREDENTIALS_INVALID"   #gen
-        - "CONSENT_INVALID"           #gen, IOBWS
-        - "CONSENT_EXPIRED"           #gen
-        - "TOKEN_UNKNOWN"             #gen
-        - "TOKEN_INVALID"             #gen
-        - "TOKEN_EXPIRED"             #gen
+        - "CERTIFICATE_INVALID"
+        - "ROLE_INVALID"
+        - "CERTIFICATE_EXPIRED"
+        - "CERTIFICATE_BLOCKED"
+        - "CERTIFICATE_REVOKE"
+        - "CERTIFICATE_MISSING"
+        - "SIGNATURE_INVALID"
+        - "SIGNATURE_MISSING"
+        - "TOKEN_UNKNOWN"
+        - "TOKEN_INVALID"
+        - "TOKEN_EXPIRED"
 
     MessageCode403:
-      description: Message codes defined for HTTP Error code 403 (FORBIDDEN).
+      description: Message codes for HTTP error code 403 (FORBIDDEN).
       type: string
       enum:
-        - "SERVICE_BLOCKED"           #gen
-        - "RESOURCE_UNKNOWN"          #gen
-        - "RESOURCE_EXPIRED"          #gen
+        - "SERVICE_BLOCKED"
+        - "RESOURCE_UNKNOWN"
+        - "RESOURCE_EXPIRED"
 
     MessageCode404:
-      description: Message codes defined for HTTP Error code 404 (NOT FOUND).
+      description: Message codes for HTTP error code 404 (NOT FOUND).
       type: string
       enum:
-        - "RESOURCE_UNKNOWN"          #gens
-
-    MessageCode405:
-      description: Message codes defined for HTTP Error code 405 (METHOD NOT ALLOWED).
-      type: string
-      enum:
-        - "SERVICE_INVALID"           #gens
-
-    MessageCode406:
-      description: Message codes defined for HTTP Error code 406 (NOT ACCEPTABLE).
-      type: string
-      enum:
-        - "REQUESTED_FORMATS_INVALID"  #IOBWS
-
-    MessageCode409:
-      description: Message codes defined for HTTP Error code 409 (CONFLICT).
-      type: string
-      enum:
-        - "STATUS_INVALID"            #gen
+        - "RESOURCE_UNKNOWN"
 
     MessageCode429:
-      description: Message codes for HTTP Error code 429 (TOO MANY REQUESTS).
+      description: Message codes for HTTP error code 429 (TOO MANY REQUESTS).
       type: string
       enum:
-        - "ACCESS_EXCEEDED"           #IOBWS
+        - "ACCESS_EXCEEDED"
 
-    #####################################################
-    # Proprietary messages
-    #####################################################
-
-    messageText:
-      description: Additional explaining text.
+    MessageCode500:
+      description: Message codes for HTTP error code 500 (INTERNAL SERVER ERROR).
       type: string
-      maxLength: 500
+      enum:
+        - "INTERNAL_ERROR"
+        - "DOWNSTREAM_ERROR"
 
-    message400:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode400"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-    message401:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode401"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-    message403:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode403"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-    message404:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode404"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-    message405:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode405"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-    message406:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode406"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-    message409:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode409"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-    message429:
-      type: object
-      required:
-        - category
-        - code
-      properties:
-        category:
-          $ref: "#/components/schemas/messageCategory"
-        code:
-          $ref: "#/components/schemas/MessageCode429"
-        path:
-          type: string
-        text:
-          $ref: "#/components/schemas/messageText"
-
-
-    #####################################################
-    # RFC7807 Messages
-    #####################################################
-
-    errorTitle:
-      description: |
-        Short human readable description of error type.
-        Could be in local language.
-        To be provided by Banks.
+    MessageCode503:
+      description: Message codes for HTTP error code 503 (SERVICE UNAVAILABLE).
       type: string
-      maxLength: 70
-
-    errorDetail:
-      description: |
-        Detailed human readable text specific to this instance of the error.
-        XPath might be used to point to the issue generating the error in addition.
-        Remark for Future: In future, a dedicated field might be introduced for the XPath.
-      type: string
-      maxLength: 500
+      enum:
+        - "SERVICE_UNAVAILABLE"
 
     #####################################################
-    # RFC7807 Messages
+    # RFC7807 Error Schemas
     #####################################################
 
     Error400:
       description: |
-        Standardised definition of reporting error information according to [RFC7807]
-        in case of a HTTP error code 400.
+        Error information according to [RFC7807] for HTTP error code 400.
+        Uses oneOf to distinguish between format errors and validation errors.
+      oneOf:
+        - $ref: "#/components/schemas/FormatError"
+        - $ref: "#/components/schemas/ValidationError"
+      discriminator:
+        propertyName: code
+        mapping:
+          FORMAT_ERROR: "#/components/schemas/FormatError"
+          VALIDATION_ERROR: "#/components/schemas/ValidationError"
+
+    FormatError:
+      description: |
+        The request body is malformed (e.g. invalid JSON syntax, wrong encoding).
       type: object
       required:
         - type
@@ -1674,46 +1874,96 @@ components:
         type:
           description: |
             A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
           type: string
           format: uri
           maxLength: 70
         title:
           description: |
             Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
           type: string
           maxLength: 70
         detail:
           description: |
             Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
           type: string
           maxLength: 500
         code:
-          $ref: "#/components/schemas/MessageCode400"
-        additionalErrors:
+          type: string
+          enum:
+            - "FORMAT_ERROR"
+        meta:
           description: |
-            Array of Error Information Blocks.
+            Free-form object for additional metadata about the error.
+          type: object
 
-            Might be used if more than one error is to be communicated
+    ValidationError:
+      description: |
+        The request is well-formed but fails schema or business validation.
+      type: object
+      required:
+        - type
+        - code
+        - errors
+      properties:
+        type:
+          description: |
+            A URI reference [RFC3986] that identifies the problem type.
+          type: string
+          format: uri
+          maxLength: 70
+        title:
+          description: |
+            Short human readable description of error type.
+          type: string
+          maxLength: 70
+        code:
+          type: string
+          enum:
+            - "VALIDATION_ERROR"
+        errors:
+          description: |
+            List of all validation errors found in the request.
           type: array
-          items: #ErrorInformation
-            description: This is a data element to support the declaration of additional errors in the context of [RFC7807].
+          minItems: 1
+          items:
             type: object
             required:
-              - code
+              - source
+              - path
+              - detail
             properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
+              source:
+                description: |
+                  The part of the request that contains the invalid input.
+                type: string
+                enum:
+                  - "query"
+                  - "body"
+                  - "path"
+                  - "header"
+              path:
+                description: |
+                  Path to the field that caused the error (e.g. "documents[0].senderId").
+                type: string
+                maxLength: 200
               detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode400"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
+                description: |
+                  Human readable description of the validation error.
+                type: string
+                maxLength: 500
+              value:
+                description: |
+                  The rejected value. Optional, and should be omitted for sensitive fields.
+                type: string
+                maxLength: 200
+              meta:
+                description: |
+                  Free-form object for additional metadata about the error.
+                type: object
+        meta:
+          description: |
+            Free-form object for additional metadata about the error.
+          type: object
 
     Error401:
       description: |
@@ -1727,46 +1977,25 @@ components:
         type:
           description: |
             A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
           type: string
           format: uri
           maxLength: 70
         title:
           description: |
             Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
           type: string
           maxLength: 70
         detail:
           description: |
             Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
           type: string
           maxLength: 500
         code:
           $ref: "#/components/schemas/MessageCode401"
-        additionalErrors:
+        meta:
           description: |
-            Array of Error Information Blocks.
-
-            Might be used if more than one error is to be communicated
-          type: array
-          items: #ErrorInformation
-            description: This is a data element to support the declaration of additional errors in the context of [RFC7807].
-            type: object
-            required:
-              - code
-            properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
-              detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode401"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
+            Free-form object for additional metadata about the error.
+          type: object
 
     Error403:
       description: |
@@ -1780,46 +2009,25 @@ components:
         type:
           description: |
             A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
           type: string
           format: uri
           maxLength: 70
         title:
           description: |
             Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
           type: string
           maxLength: 70
         detail:
           description: |
             Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
           type: string
           maxLength: 500
         code:
           $ref: "#/components/schemas/MessageCode403"
-        additionalErrors:
+        meta:
           description: |
-            Array of Error Information Blocks.
-
-            Might be used if more than one error is to be communicated
-          type: array
-          items: #ErrorInformation
-            description: This is a data element to support the declaration of additional errors in the context of [RFC7807].
-            type: object
-            required:
-              - code
-            properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
-              detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode403"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
+            Free-form object for additional metadata about the error.
+          type: object
 
     Error404:
       description: |
@@ -1833,205 +2041,25 @@ components:
         type:
           description: |
             A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
           type: string
           format: uri
           maxLength: 70
         title:
           description: |
             Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
           type: string
           maxLength: 70
         detail:
           description: |
             Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
           type: string
           maxLength: 500
         code:
           $ref: "#/components/schemas/MessageCode404"
-        additionalErrors:
+        meta:
           description: |
-            Array of Error Information Blocks.
-
-            Might be used if more than one error is to be communicated
-          type: array
-          items: #ErrorInformation
-            description: This is a data element to support the declaration of additional errors in the context of [RFC7807].
-            type: object
-            required:
-              - code
-            properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
-              detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode404"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error405:
-      description: |
-        Standardised definition of reporting error information according to [RFC7807]
-        in case of a HTTP error code 405.
-      type: object
-      required:
-        - type
-        - code
-      properties:
-        type:
-          description: |
-            A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
-          type: string
-          format: uri
-          maxLength: 70
-        title:
-          description: |
-            Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
-          type: string
-          maxLength: 70
-        detail:
-          description: |
-            Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
-          type: string
-          maxLength: 500
-        code:
-          $ref: "#/components/schemas/MessageCode405"
-        additionalErrors:
-          description: |
-            Array of Error Information Blocks.
-
-            Might be used if more than one error is to be communicated
-          type: array
-          items: #ErrorInformation
-            description: This is a data element to support the declaration of additional errors in the context of [RFC7807].
-            type: object
-            required:
-              - code
-            properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
-              detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode405"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error406:
-      description: |
-        Standardised definition of reporting error information according to [RFC7807]
-        in case of a HTTP error code 406.
-      type: object
-      required:
-        - type
-        - code
-      properties:
-        type:
-          description: |
-            A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
-          type: string
-          format: uri
-          maxLength: 70
-        title:
-          description: |
-            Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
-          type: string
-          maxLength: 70
-        detail:
-          description: |
-            Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
-          type: string
-          maxLength: 500
-        code:
-          $ref: "#/components/schemas/MessageCode406"
-        additionalErrors:
-          description: |
-            Array of Error Information Blocks.
-
-            Might be used if more than one error is to be communicated
-          type: array
-          items: #ErrorInformation
-            description: This is a data element to support the declaration of additional errors in the context of [RFC7807].
-            type: object
-            required:
-              - code
-            properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
-              detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode406"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error409:
-      description: |
-        Standardised definition of reporting error information according to [RFC7807]
-        in case of a HTTP error code 409.
-      type: object
-      required:
-        - type
-        - code
-      properties:
-        type:
-          description: |
-            A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
-          type: string
-          format: uri
-          maxLength: 70
-        title:
-          description: |
-            Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
-          type: string
-          maxLength: 70
-        detail:
-          description: |
-            Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
-          type: string
-          maxLength: 500
-        code:
-          $ref: "#/components/schemas/MessageCode409"
-        additionalErrors:
-          description: |
-            Array of Error Information Blocks.
-
-            Might be used if more than one error is to be communicated
-          type: array
-          items: #ErrorInformation
-            description: This is a data element to support the declaration of additional errors in the context of [RFC7807].
-            type: object
-            required:
-              - code
-            properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
-              detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode409"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
+            Free-form object for additional metadata about the error.
+          type: object
 
     Error429:
       description: |
@@ -2045,181 +2073,121 @@ components:
         type:
           description: |
             A URI reference [RFC3986] that identifies the problem type.
-            These URI will be provided by IOBWS as part of future technical specifications.
           type: string
           format: uri
           maxLength: 70
         title:
           description: |
             Short human readable description of error type.
-            Could be in local language.
-            To be provided by Banks.
           type: string
           maxLength: 70
         detail:
           description: |
             Detailed human readable text specific to this instance of the error.
-            XPath might be used to point to the issue generating the error in addition.
-            Remark for Future: In future, a dedicated field might be introduced for the XPath.
           type: string
           maxLength: 500
         code:
           $ref: "#/components/schemas/MessageCode429"
-        additionalErrors:
+        meta:
           description: |
-            Array of Error Information Blocks.
+            Free-form object for additional metadata about the error.
+          type: object
 
-            Might be used if more than one error is to be communicated
-          type: array
-          items: #ErrorInformation
-            description: |
-              This is a data element to support the declaration of additional errors in the context of [RFC7807]
-              in case of a HTTP error code 429 for.
-            type: object
-            required:
-              - code
-            properties:
-              title:
-                $ref: "#/components/schemas/errorTitle"
-              detail:
-                $ref: "#/components/schemas/errorDetail"
-              code:
-                $ref: "#/components/schemas/MessageCode429"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error400_IOBWS:
+    Error500:
       description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 400.
+        Standardised definition of reporting error information according to [RFC7807]
+        in case of a HTTP error code 500.
       type: object
+      required:
+        - type
+        - code
       properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message400"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
+        type:
+          description: |
+            A URI reference [RFC3986] that identifies the problem type.
+          type: string
+          format: uri
+          maxLength: 70
+        title:
+          description: |
+            Short human readable description of error type.
+          type: string
+          maxLength: 70
+        detail:
+          description: |
+            Detailed human readable text specific to this instance of the error.
+          type: string
+          maxLength: 500
+        code:
+          $ref: "#/components/schemas/MessageCode500"
+        meta:
+          description: |
+            Free-form object for additional metadata about the error.
+          type: object
 
-    Error401_IOBWS:
+    Error503:
       description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 401.
+        Standardised definition of reporting error information according to [RFC7807]
+        in case of a HTTP error code 503.
       type: object
+      required:
+        - type
+        - code
       properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message401"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
+        type:
+          description: |
+            A URI reference [RFC3986] that identifies the problem type.
+          type: string
+          format: uri
+          maxLength: 70
+        title:
+          description: |
+            Short human readable description of error type.
+          type: string
+          maxLength: 70
+        detail:
+          description: |
+            Detailed human readable text specific to this instance of the error.
+          type: string
+          maxLength: 500
+        code:
+          $ref: "#/components/schemas/MessageCode503"
+        meta:
+          description: |
+            Free-form object for additional metadata about the error.
+          type: object
 
-    Error403_IOBWS:
-      description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 403.
-      type: object
-      properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message403"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error404_IOBWS:
-      description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 404.
-      type: object
-      properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message404"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error405_IOBWS:
-      description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 405.
-      type: object
-      properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message405"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error406_IOBWS:
-      description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 406.
-      type: object
-      properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message406"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-
-    Error409_IOBWS:
-      description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 409.
-      type: object
-      properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message409"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-      example:
-        {
-          "messages": [
-            {
-              "category": "ERROR",
-              "code": "STATUS_INVALID",
-              "text": "additional text information of the Bank up to 500 characters"
-            }
-          ]
-        }
-
-    Error429_IOBWS:
-      description: |
-        IOBWS specific definition of reporting error information in case of a HTTP error code 429.
-      type: object
-      properties:
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/message429"
-        _links:
-          $ref: "#/components/schemas/_linksAll"
-      example:
-        {
-          "messages": [
-            {
-              "category": "ERROR",
-              "code": "ACCESS_EXCEEDED",
-              "text": "additional text information of the Bank up to 500 characters"
-            }
-          ]
-        }
 
   requestBodies:
     #####################################################
     # Reusable Request Bodies
     #####################################################
 
-    documentsProcessInitiation:
+    batchInitiation:
       description: |
-        JSON request body for a document process initiation or update request message
+        JSON request body for a batch initiation or update request message
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentProcessDetails"
+            $ref: "#/components/schemas/batchDetails"
           examples: 
             example:
-              $ref: "#/components/examples/documentsProcessInitiation_json_Example"
+              $ref: "#/components/examples/batchInitiation_json_Example"
+
+    documentInitiation:
+      description: |
+        JSON request body for creating a single document
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentInitiationDetails"
+          examples:
+            pdf:
+              $ref: "#/components/examples/documentInitiation_pdf_Example"
+            xml:
+              $ref: "#/components/examples/documentInitiation_xml_Example"
 
     createCrossReferences:
       description: |
@@ -2233,17 +2201,41 @@ components:
             example:
               $ref: "#/components/examples/createCrossReferences_json_Example"
 
-    updateCrossReferences:
+    updateCrossReference:
       description: |
-        JSON request body for a cross-references update request message
+        JSON request body for updating a single cross-reference.
       required: true
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/crossReferencesList"
-          examples: 
+            $ref: "#/components/schemas/crossReferenceUpdate"
+          examples:
             example:
-              $ref: "#/components/examples/updateCrossReferences_json_Example"     
+              $ref: "#/components/examples/updateCrossReference_json_Example"
+
+    deleteCrossReferences:
+      description: |
+        JSON request body for deleting cross-references.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/crossReferenceDeletionRequest"
+          examples:
+            example:
+              $ref: "#/components/examples/deleteCrossReferences_json_Example"
+
+    createDocumentTypes:
+      description: |
+        JSON request body for creating document types for a sender
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentTypeCreationList"
+          examples:
+            example:
+              $ref: "#/components/examples/createDocumentTypes_json_Example"
 
   headers:
     #####################################################
@@ -2257,6 +2249,12 @@ components:
       schema:
         type: string
         format: uuid
+
+    Storage-System:
+      description: |
+        The storage system used for this response.
+      schema:
+        $ref: "#/components/schemas/storageCode"
 
     Location:
       description: |
@@ -2301,8 +2299,21 @@ components:
     # Positive Responses
     #####################################################
 
-    OK_200_DocumentsProcessListWithStatusDetails:
-      description: Get document process details
+    OK_200_BatchWithStatusDetails:
+      description: Get batch details
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/batchWithStatusDetails"
+          examples: 
+            example:
+              $ref: "#/components/examples/batchWithStatusDetails-200_json_Example"
+
+    OK_200_BatchItems:
+      description: Paginated list of batch items
       headers:
         X-Paging-CurrentPage:
           $ref: "#/components/headers/X-Paging-CurrentPage"
@@ -2317,40 +2328,61 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/documentProcessWithStatusList"
-          examples: 
-            example:
-              $ref: "#/components/examples/documentProcessWithStatusList-200_json_Example"
-
-    OK_200_DocumentsProcessWithStatusDetails:
-      description: Get document process details
-      headers:
-        Location:
-          $ref: "#/components/headers/Location"
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/documentProcessWithStatusDetails"
-          examples: 
-            example:
-              $ref: "#/components/examples/documentProcessWithStatusDetails-200_json_Example"
-
-    CREATED_201_DocumentsProcessWithStatusDetails:
-      description: Document process created
-      headers:
-        Location:
-          $ref: "#/components/headers/Location"
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/documentProcessWithStatusDetails"
+            $ref: "#/components/schemas/batchItemList"
           examples:
             example:
-              $ref: "#/components/examples/documentProcessWithStatusDetails-200_json_Example"
+              $ref: "#/components/examples/batchItems-200_json_Example"
+
+    OK_200_BatchList:
+      description: Paginated list of batches
+      headers:
+        X-Paging-CurrentPage:
+          $ref: "#/components/headers/X-Paging-CurrentPage"
+        X-Paging-TotalPages:
+          $ref: "#/components/headers/X-Paging-TotalPages"
+        X-Paging-TotalItems:
+          $ref: "#/components/headers/X-Paging-TotalItems"
+        X-Paging-PerPage:
+          $ref: "#/components/headers/X-Paging-PerPage"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/batchList"
+          examples:
+            example:
+              $ref: "#/components/examples/batchList-200_json_Example"
+
+    CREATED_201_BatchWithStatusDetails:
+      description: Batch created
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/batchCreated"
+          examples:
+            example:
+              $ref: "#/components/examples/batchCreated-201_json_Example"
+
+    CREATED_201_Document:
+      description: Document created
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentCreated"
+          examples:
+            example:
+              $ref: "#/components/examples/documentCreated-201_json_Example"
 
     OK_200_DocumentWithStatusDetails:
       description: Get document details
@@ -2360,7 +2392,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/fileWithStatusDetails"
+            $ref: "#/components/schemas/documentDetail"
 
     OK_200_DocumentListWithStatusDetails:
       description: Get document list details
@@ -2380,19 +2412,6 @@ components:
           schema:
             $ref: "#/components/schemas/documentWithStatusList"
 
-    OK_200_UpdateDocumentsProcess:
-      description: OK
-      headers:
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/documentProcessWithStatusDetails"
-          examples: 
-            example:
-              $ref: "#/components/examples/documentProcessWithStatusDetails-200_json_Example"
-
     OK_200_DocumentTypeDetails:
       description: OK
       headers:
@@ -2406,6 +2425,21 @@ components:
             example:
               $ref: "#/components/examples/documentTypeListResponse-200_json_Example"
 
+    CREATED_201_DocumentTypes:
+      description: Result of a batch document type creation request.
+      headers:
+        Location:
+          $ref: "#/components/headers/Location"
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/documentTypeCreationResult"
+          examples:
+            example:
+              $ref: "#/components/examples/createDocumentTypes-201_json_Example"
+
     OK_200_CreateCrossReferences:
       description: |
         Cross-references created successfully.
@@ -2417,12 +2451,19 @@ components:
 
     CREATED_201_CreateCrossReferences:
       description: |
-        Cross-references created successfully.
+        Result of a batch cross-reference creation request.
       headers:
         Location:
           $ref: "#/components/headers/Location"
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/crossReferenceCreationResult"
+          examples:
+            example:
+              $ref: "#/components/examples/createCrossReferences-201_json_Example"
 
     OK_200_QueryCrossReferences:
       description: |
@@ -2460,16 +2501,36 @@ components:
             "Example":
               $ref: "#/components/examples/getCrossReferences-200_json_Example"
 
-    OK_200_UpdateCrossReferences:
-      description: |
-        Cross-references updated successfully.
+    OK_200_CrossReference:
+      description: Single cross-reference details
       headers:
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/crossReference"
+          examples:
+            example:
+              $ref: "#/components/examples/getCrossReference-200_json_Example"
 
     OK_200_DeleteCrossReferences:
       description: |
-        Cross-references deleted successfully.
+        Result of a batch cross-reference deletion request.
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/X-Request-ID"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/crossReferenceDeletionResult"
+          examples:
+            example:
+              $ref: "#/components/examples/deleteCrossReferences-200_json_Example"
+
+    OK_200_DeleteCrossReference:
+      description: |
+        Cross-reference deleted successfully.
       headers:
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
@@ -2490,11 +2551,75 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error400_IOBWS"
+            $ref: "#/components/schemas/Error400"
+          examples:
+            formatError:
+              summary: Format Error
+              value:
+                type: "https://<domain>/problems/format-error"
+                code: "FORMAT_ERROR"
+                title: "Malformed request body"
+                detail: "Expected valid JSON but found syntax error at position 42"
+            validationErrorSingle:
+              summary: Validation Error (single)
+              value:
+                type: "https://<domain>/problems/validation-error"
+                code: "VALIDATION_ERROR"
+                title: "Validation failed"
+                errors:
+                  - source: "body"
+                    path: "senderId"
+                    detail: "senderId is required"
+            validationErrorMultiple:
+              summary: Validation Error (multiple)
+              value:
+                type: "https://<domain>/problems/validation-error"
+                code: "VALIDATION_ERROR"
+                title: "Validation failed"
+                errors:
+                  - source: "body"
+                    path: "documents[0].documentTypeCode"
+                    detail: "must be a valid code"
+                    value: "INVALID"
+                  - source: "body"
+                    path: "documents[1].file"
+                    detail: "file is required"
 
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Error400"
+          examples:
+            formatError:
+              summary: Format Error
+              value:
+                type: "https://<domain>/problems/format-error"
+                code: "FORMAT_ERROR"
+                title: "Malformed request body"
+                detail: "Expected valid JSON but found syntax error at position 42"
+            validationErrorSingle:
+              summary: Validation Error (single)
+              value:
+                type: "https://<domain>/problems/validation-error"
+                code: "VALIDATION_ERROR"
+                title: "Validation failed"
+                errors:
+                  - source: "body"
+                    path: "senderId"
+                    detail: "senderId is required"
+            validationErrorMultiple:
+              summary: Validation Error (multiple)
+              value:
+                type: "https://<domain>/problems/validation-error"
+                code: "VALIDATION_ERROR"
+                title: "Validation failed"
+                errors:
+                  - source: "body"
+                    path: "documents[0].documentTypeCode"
+                    detail: "must be a valid code"
+                    value: "INVALID"
+                  - source: "body"
+                    path: "documents[1].file"
+                    detail: "file is required"
 
     UNAUTHORIZED_401:
       description: Unauthorized
@@ -2508,7 +2633,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error401_IOBWS"
+            $ref: "#/components/schemas/Error401"
 
         application/problem+json:
           schema:
@@ -2526,7 +2651,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error403_IOBWS"
+            $ref: "#/components/schemas/Error403"
 
         application/problem+json:
           schema:
@@ -2544,83 +2669,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error404_IOBWS"
+            $ref: "#/components/schemas/Error404"
 
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Error404"
-
-    METHOD_NOT_ALLOWED_405:
-      description: Method Not Allowed
-
-      headers:
-        Location:
-          $ref: "#/components/headers/Location"
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error405_IOBWS"
-
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/Error405"
-
-    NOT_ACCEPTABLE_406:
-      description: Not Acceptable
-
-      headers:
-        Location:
-          $ref: "#/components/headers/Location"
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error406_IOBWS"
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/Error406"
-
-    REQUEST_TIMEOUT_408:
-      description: Request Timeout
-
-      headers:
-        Location:
-          $ref: "#/components/headers/Location"
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-      #No Response body because there are no valid message codes in case of HTTP code 408
-
-    CONFLICT_409:
-      description: Conflict
-
-      headers:
-        Location:
-          $ref: "#/components/headers/Location"
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error409_IOBWS"
-
-        application/problem+json:
-          schema:
-            $ref: "#/components/schemas/Error409"
-
-    UNSUPPORTED_MEDIA_TYPE_415:
-      description: Unsupported Media Type
-
-      headers:
-        Location:
-          $ref: "#/components/headers/Location"
-        X-Request-ID:
-          $ref: "#/components/headers/X-Request-ID"
-      #No Response body because there are no valid message codes in case of HTTP code 415
 
     TOO_MANY_REQUESTS_429:
       description: Too Many Requests
@@ -2634,9 +2687,8 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error429_IOBWS"
+            $ref: "#/components/schemas/Error429"
         application/problem+json:
-
           schema:
             $ref: "#/components/schemas/Error429"
 
@@ -2647,7 +2699,13 @@ components:
           $ref: "#/components/headers/Location"
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
-      #No Response body because there are no valid message codes in case of HTTP code 500
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error500"
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/Error500"
 
     SERVICE_UNAVAILABLE_503:
       description: Service Unavailable
@@ -2656,7 +2714,13 @@ components:
           $ref: "#/components/headers/Location"
         X-Request-ID:
           $ref: "#/components/headers/X-Request-ID"
-      #No Response body because there are no valid message codes in case of HTTP code 503
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error503"
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/Error503"
 
   examples:
     #####################################################
@@ -2668,91 +2732,276 @@ components:
       value:
         [
           { 
-            "code": "STVO",
-            "name": "/typ/3254b7b2-302c-72",
+            "code": "HMTDL",
+            "name": "Launaseðlar",
             "durableMedia": true,
-            "description": "Pay slip from Company"
+            "description": "Launaseðlar - Hólmfríður ÞÍ Traustadóttir",
+            "fileType": "XML",
+            "categoryCode": "Payslip",
+            "categoryDescription": "Payslips"
           },
           { 
-            "code": "IDFR",
-            "name": "/typ/3254b7b2-302c-72",
+            "code": "HMTDR",
+            "name": "Reikningar",
             "durableMedia": true,
-            "description": "Account statement from Company"
+            "description": "Reikningar - Hólmfríður ÞÍ Traustadóttir",
+            "fileType": "PDF",
+            "categoryCode": "Bill",
+            "categoryDescription": "Bills"
           }
         ]
 
-    documentsProcessInitiation_json_Example:
-      description: Documents upload request.
-      value: 
+    documentCreated-201_json_Example:
+      description: Document created response.
+      value:
         {
-          "id": "3a378271-0a43-aa66-f273-377ae9ce135c",
-          "name": "Account statements",
-          "description": "Account statements for june 2022",
-          "senderKennitala": "1111111199",
-          "documentTypeCode": "IDFR",
-          "files": [
-            {
-              "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
-              "description": "Company - Account statement",
-              "receiverKennitala": "1111112239",
-              "fileType": "PDF",
-              "file": "The file in the form of base64 encoded characters"
-            },
-            {
-              "id": "3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f",
-              "description": "Company - Account statement",
-              "receiverKennitala": "1111112249",
-              "fileType": "LINK",
-              "file": "https://documents.example.com/file/3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f"
-            } 
-          ]
+          "documentId": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324"
         }
 
-    documentProcessWithStatusDetails-200_json_Example:
-      description: Document process result.
-      value: 
+    createDocumentTypes-201_json_Example:
+      description: Document type creation result.
+      value:
         {
-          "id": "3a378271-0a43-aa66-f273-377ae9ce135c",
-          "name": "Account statements",
-          "description": "Account statements for june 2022",
-          "senderKennitala": "1111111199",
-          "documentTypeCode": "IDFR",
-          "status": "received",
-          "files": [
+          "created": [
             {
-              "id": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
-              "description": "",
-              "receiverKennitala": "1111112239",
+              "code": "HMTDT",
+              "name": "Tilkynningar",
+              "durableMedia": false,
+              "description": "Tilkynningar - Hólmfríður ÞÍ Traustadóttir",
+              "fileType": "XML",
+              "categoryCode": "Notification",
+              "categoryDescription": "Tilkynningar"
+            }
+          ],
+          "failed": [
+            {
               "fileType": "PDF",
-              "status": "received",
-              "statusMessage": "File is currently being processed",
-              "isCrossReferenced": true
-            },
-            {
-              "id": "3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f",
-              "description": "",
-              "receiverKennitala": "1111112249",
-              "fileType": "LINK",
-              "status": "received",
-              "statusMessage": "File is currently being processed",
-              "isCrossReferenced": false
+              "categoryCode": "Bill",
+              "failureReason": "Document type already exists for this sender."
             }
           ]
         }
 
-    documentProcessWithStatusList-200_json_Example:
-      description: Documents query result.
+    createDocumentTypes_json_Example:
+      description: Document types creation request.
+      value:
+        [
+          {
+            "fileType": "PDF",
+            "categoryCode": "Bill"
+          },
+          {
+            "fileType": "XML",
+            "categoryCode": "Notification",
+            "email": "notifications@example.com"
+          }
+        ]
+
+    documentInitiation_pdf_Example:
+      description: Single PDF document creation request.
+      value:
+        {
+          "senderId": "1909791489",
+          "documentTypeCode": "HMTDG",
+          "externalId": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
+          "ownerId": "1909791489",
+          "reference": "Invoice 2026-001",
+          "description": "Greiðsluseðlar - Hólmfríður ÞÍ Traustadóttir",
+          "fileType": "PDF",
+          "file": ""
+        }
+
+    documentInitiation_xml_Example:
+      description: Single XML document creation request.
+      value:
+        {
+          "senderId": "1909791489",
+          "documentTypeCode": "HMTDT",
+          "externalId": "3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f",
+          "ownerId": "1909791489",
+          "reference": "Statement March 2026",
+          "description": "Tilkynningar - Hólmfríður ÞÍ Traustadóttir",
+          "fileType": "XML",
+          "file": ""
+        }
+
+    batchInitiation_json_Example:
+      description: Batch document upload request.
       value: 
+        {
+          "senderId": "1909791489",
+          "documents": [
+            {
+              "documentTypeCode": "HMTDR",
+              "externalId": "99391c7e-ad88-49ec-a2ad-99ddcb1f7721",
+              "ownerId": "1909791489",
+              "description": "Reikningar - Hólmfríður ÞÍ Traustadóttir",
+              "fileType": "PDF",
+              "file": ""
+            },
+            {
+              "documentTypeCode": "HMTDT",
+              "externalId": "3f0dce5a-6bbd-4f2d-ac4c-224894a38a4f",
+              "ownerId": "1909791489",
+              "description": "Tilkynningar - Hólmfríður ÞÍ Traustadóttir",
+              "fileType": "XML",
+              "file": ""
+            }
+          ]
+        }
+
+    batchCreated-201_json_Example:
+      description: Batch creation response.
+      value:
+        {
+          "batchId": "3a378271-0a43-aa66-f273-377ae9ce135c"
+        }
+
+    batchWithStatusDetails-200_json_Example:
+      description: Batch status result.
+      value: 
+        {
+          "id": "3a378271-0a43-aa66-f273-377ae9ce135c",
+          "name": "Reikningar",
+          "description": "Reikningar - Hólmfríður ÞÍ Traustadóttir",
+          "senderId": "1909791489",
+          "documentTypeCode": "HMTDR",
+          "status": "Completed",
+          "createdBy": "user@bank.is",
+          "createdDate": "2022-06-01T10:00:00Z",
+          "itemCount": 1,
+          "itemSuccessCount": 1,
+          "itemErrorCount": 0
+        }
+
+    batchItems-200_json_Example:
+      description: Batch items result.
+      value:
+        [
+          {
+            "documentId": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324",
+            "status": "Completed",
+            "statusMessage": "Document processed successfully"
+          },
+          {
+            "documentId": "1909791489:1909791489:a1b2c3d4-e5f6-7890-abcd-ef1234567890:20260324",
+            "status": "CompletedWithErrors",
+            "statusMessage": "Document type HMTDR is not valid for sender"
+          }
+        ]
+
+    batchList-200_json_Example:
+      description: List of batches.
+      value:
         [
           {
             "id": "3a378271-0a43-aa66-f273-377ae9ce135c",
-            "name": "Account statements",
-            "description": "Account statements for june 2022",
-            "senderKennitala": "1111111199",
-            "documentTypeCode": "IDFR",
-            "status": "received"
+            "name": "Reikningar",
+            "description": "Reikningar - Hólmfríður ÞÍ Traustadóttir",
+            "senderId": "1909791489",
+            "documentTypeCode": "HMTDR",
+            "status": "Completed",
+            "createdBy": "user@bank.is",
+            "createdDate": "2022-06-01T10:00:00Z",
+            "itemCount": 150,
+            "itemSuccessCount": 148,
+            "itemErrorCount": 2
+          },
+          {
+            "id": "b7e1d290-5c8a-4f12-9a3b-6d4e8f2c1a0b",
+            "name": "Launaseðlar",
+            "description": "Launaseðlar - Hólmfríður ÞÍ Traustadóttir",
+            "senderId": "1909791489",
+            "documentTypeCode": "HMTDL",
+            "status": "InProgress",
+            "createdBy": "user@bank.is",
+            "createdDate": "2022-06-02T14:30:00Z",
+            "itemCount": 75,
+            "itemSuccessCount": 50,
+            "itemErrorCount": 0
           }
         ]
+
+    updateCrossReference_json_Example:
+      description: Cross-reference update request.
+      value:
+        {
+          "category": "CollectionLetter",
+          "description": "Updated collection letter description.",
+          "effectiveDate": "2024-06-01",
+          "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
+        }
+
+    deleteCrossReferences_json_Example:
+      description: Cross-references deletion request.
+      value:
+        {
+          "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2",
+          "crossReferences": [
+            {
+              "documentId": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324",
+              "keyType": "Claim",
+              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528"
+            },
+            {
+              "documentId": "1909791489:1909791489:b7e2d4f1-6c3a-4a8e-9f12-8d5e7a3c1b09:20260315",
+              "keyType": "Claim",
+              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528"
+            }
+          ]
+        }
+
+    deleteCrossReferences-200_json_Example:
+      description: Cross-references deletion result.
+      value:
+        {
+          "deleted": [
+            {
+              "documentId": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324",
+              "keyType": "Claim",
+              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528"
+            }
+          ],
+          "failed": [
+            {
+              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
+              "keyType": "Claim",
+              "document": {
+                "id": "1909791489:1909791489:b7e2d4f1-6c3a-4a8e-9f12-8d5e7a3c1b09:20260315"
+              },
+              "failureReason": "Cross-reference not found."
+            }
+          ]
+        }
+
+    createCrossReferences-201_json_Example:
+      description: Cross-references creation result.
+      value:
+        {
+          "created": [
+            {
+              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
+              "keyType": "Claim",
+              "document": {
+                "id": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324",
+                "category": "Bill",
+                "description": "Bill for services rendered.",
+                "effectiveDate": "2024-04-01"
+              },
+              "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
+            }
+          ],
+          "failed": [
+            {
+              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
+              "keyType": "Claim",
+              "document": {
+                "id": "1909791489:1909791489:b7e2d4f1-6c3a-4a8e-9f12-8d5e7a3c1b09:20260315"
+              },
+              "failureReason": "Cross-reference already exists."
+            }
+          ]
+        }
 
     createCrossReferences_json_Example:
       description: Cross-references creation request.
@@ -2761,21 +3010,23 @@ components:
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
               "keyType": "Claim",
-              "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
-              "documentStore": "Ark",
-              "documentCategory": "Bill",
-              "documentDescription": "Bill for services rendered.",
-              "documentEffectiveDate": "2024-04-01",
+              "document": {
+                "id": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324",
+                "category": "Bill",
+                "description": "Bill for services rendered.",
+                "effectiveDate": "2024-04-01"
+              },
               "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
           },
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
               "keyType": "Claim",
-              "documentId": "42fbcce1-35a9-4ec3-8b40-c9a73fc3b8fe",
-              "documentStore": "RBS",
-              "documentCategory": "CollectionLetter",
-              "documentDescription": "Collection letter.",
-              "documentEffectiveDate": "2024-05-01",
+              "document": {
+                "id": "1909791489:1909791489:b7e2d4f1-6c3a-4a8e-9f12-8d5e7a3c1b09:20260315",
+                "category": "CollectionLetter",
+                "description": "Collection letter.",
+                "effectiveDate": "2024-05-01"
+              },
               "externalEventId": "e7c58d4e-8cd8-462f-b440-3124f4b6e0bd"
           }
         ]
@@ -2787,21 +3038,23 @@ components:
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
               "keyType": "Claim",
-              "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
-              "documentStore": "Ark",
-              "documentCategory": "Bill",
-              "documentDescription": "Bill for services rendered.",
-              "documentEffectiveDate": "2024-04-01",
+              "document": {
+                "id": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324",
+                "category": "Bill",
+                "description": "Bill for services rendered.",
+                "effectiveDate": "2024-04-01"
+              },
               "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
           },
           {
               "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
               "keyType": "Claim",
-              "documentId": "42fbcce1-35a9-4ec3-8b40-c9a73fc3b8fe",
-              "documentStore": "RBS",
-              "documentCategory": "CollectionLetter",
-              "documentDescription": "Collection letter.",
-              "documentEffectiveDate": "2024-05-01",
+              "document": {
+                "id": "1909791489:1909791489:b7e2d4f1-6c3a-4a8e-9f12-8d5e7a3c1b09:20260315",
+                "category": "CollectionLetter",
+                "description": "Collection letter.",
+                "effectiveDate": "2024-05-01"
+              },
               "externalEventId": "e7c58d4e-8cd8-462f-b440-3124f4b6e0bd"
           }
         ]
@@ -2812,39 +3065,14 @@ components:
         {
           "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
           "keyType": "Claim",
-          "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
-          "documentStore": "Ark",
-          "documentCategory": "Bill",
-          "documentDescription": "Bill for services rendered.",
-          "documentEffectiveDate": "2024-04-01",
+          "document": {
+            "id": "1909791489:1909791489:99391c7e-ad88-49ec-a2ad-99ddcb1f7721:20260324",
+            "category": "Bill",
+            "description": "Bill for services rendered.",
+            "effectiveDate": "2024-04-01"
+          },
           "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
         }
-
-    updateCrossReferences_json_Example:
-      description: Cross-references update request.
-      value: 
-        [
-          {
-              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": "Claim",
-              "documentId": "00ec5225-8a64-48a2-b6bf-f4ef558b27df",
-              "documentStore": "Ark",
-              "documentCategory": "Bill",
-              "documentDescription": "Bill for services rendered.",
-              "documentEffectiveDate": "2024-04-01",
-              "externalEventId": "edd45ff6-265e-4cda-8d58-bdefea00acd2"
-          },
-          {
-              "key": "cc15b0b1-eea5-4c65-adc9-b61a83fae528",
-              "keyType": "Claim",
-              "documentId": "42fbcce1-35a9-4ec3-8b40-c9a73fc3b8fe",
-              "documentStore": "RBS",
-              "documentCategory": "CollectionLetter",
-              "documentDescription": "Collection letter.",
-              "documentEffectiveDate": "2024-05-01",
-              "externalEventId": "e7c58d4e-8cd8-462f-b440-3124f4b6e0bd"
-          }
-        ]
 
 security:
   #####################################################
@@ -2857,13 +3085,7 @@ tags:
   # Predefined Tags to Group Methods
   #####################################################
 
-  - name: Document Service (DS)
-    description: |
-      The API interface for Documents offers the following services:
-        * Initiation and update of a document request
-        * Status information of a document
-        * Document types
-        
-  - name: Cross-Reference Service (CRS)
-    description: |
-      The API interface for Cross-References offer means to create, read, update and delete cross-references between documents and other objects such as claims, credit transfers and payment requests.
+  - name: Document Types
+  - name: Documents
+  - name: Batches
+  - name: Cross-References


### PR DESCRIPTION
Closes #289

Builds on PR #287. Should be merged after or squashed together with #287.

Follow-up fixes to the Documents API overhaul:

- Remove false RFC 7807 references from error schema descriptions
- Document non-implemented batch functionality (Q3 review caveat)
- Document searchDocuments limitation (ownerId always required)
- Relax batchId from UUID to free-form string
- Remove `description` from document creation request (response-only field)
- Add `submittingId` to document type creation (matches SOAP CreateDocumentTypes)
- Restructure `documentTypeDetails` response to match WSDL shape (nested category, fileName, email, senderName wrapper)
- Add `externalId` query parameter to searchDocuments
- Add `styleSheetName` to XML document creation payload

https://petstore.swagger.io/?url=https://raw.githubusercontent.com/arnarion/IST-FUT-FMTH/fix/documents-overhaul/Deliverables/IOBWS-Documents3.1.yaml